### PR TITLE
Fixed edit window padding issue when display type is tiled.

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.couchEdit.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.couchEdit.css
@@ -2,6 +2,8 @@
 
 /* DIV that holds editor accordion */
 .n2CouchEditor_container {
+	padding: 15px 20px;
+	width: 600px;
 }
 
 /* Remove extra white space in accordion */


### PR DESCRIPTION
Added css styling for the .n2CouchEditor_container class, defining the width and padding. This solves the issue of the edit window being placed against the edge of the display side panel. 