### PR TITLE
PDF Thumbnails with black backgrounds fix

### DIFF
--- a/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/imageMagick/ImageMagickProcessorDefault.java
+++ b/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/imageMagick/ImageMagickProcessorDefault.java
@@ -18,7 +18,7 @@ public class ImageMagickProcessorDefault implements ImageMagickProcessor {
 	
 	static public String imageInfoCommand = "identify -verbose %1$s[0]";
 	static public String imageConvertCommand = "convert -monitor -auto-orient %1$s[0] -compress JPEG -quality 70 %2$s";
-	static public String imageResizeCommand = "convert -monitor -auto-orient %1$s[0] -resize %3$dx%4$d> -compress JPEG -quality 70 %2$s";
+	static public String imageResizeCommand = "convert -monitor -auto-orient %1$s[0] -resize %3$dx%4$d> -compress JPEG -alpha flatten -quality 70 %2$s";
 	static public String imageReorientCommand = "convert -monitor -auto-orient %1$s[0] %2$s";
 
 	static private Pattern patternInfoGeometry = Pattern.compile("^\\s*Geometry:\\s*(\\d+)x(\\d+)");


### PR DESCRIPTION
Added the command line option -alpha flatten for the ImageMagick convert command. 

Fixes the black background thumbnail creation issue when generating pdf
thumbnails.