### PR TITLE
PDF Thumbnails with black backgrounds fix

### DIFF
--- a/nunaliit2-couch-sdk/src/main/templates/config/multimedia.properties
+++ b/nunaliit2-couch-sdk/src/main/templates/config/multimedia.properties
@@ -5,7 +5,7 @@
 #ffmpegCreateThumbnailCommand=avconv -y -ss 00:00:05 -i %1$s -s %3$dx%4$d -r 1 -vframes 1 -f image2 %2$s
 #imageInfoCommand=identify -verbose %1$s[0]
 #imageConvertCommand=convert -monitor -auto-orient %1$s[0] -compress JPEG -quality 70 %2$s
-#imageResizeCommand=convert -monitor -auto-orient %1$s[0] -resize %3$dx%4$d> -compress JPEG -quality 70 %2$s
+#imageResizeCommand=convert -monitor -auto-orient %1$s[0] -resize %3$dx%4$d> -compress JPEG -alpha flatten -quality 70 %2$s
 #imageReorientCommand=convert -monitor -auto-orient %1$s[0] %2$s
 #imageMaxHeight=1000
 #imageMaxWidth=1000

--- a/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/imageMagick/ImageMagickProcessorDefault.java
+++ b/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/imageMagick/ImageMagickProcessorDefault.java
@@ -18,7 +18,7 @@ public class ImageMagickProcessorDefault implements ImageMagickProcessor {
 	
 	static public String imageInfoCommand = "identify -verbose %1$s[0]";
 	static public String imageConvertCommand = "convert -monitor -auto-orient %1$s[0] -compress JPEG -quality 70 %2$s";
-	static public String imageResizeCommand = "convert -monitor -auto-orient %1$s[0] -resize %3$dx%4$d> -compress JPEG -quality 70 %2$s";
+	static public String imageResizeCommand = "convert -monitor -auto-orient %1$s[0] -resize %3$dx%4$d> -compress JPEG -alpha flatten -quality 70 %2$s";
 	static public String imageReorientCommand = "convert -monitor -auto-orient %1$s[0] %2$s";
 
 	static private Pattern patternInfoGeometry = Pattern.compile("^\\s*Geometry:\\s*(\\d+)x(\\d+)");

--- a/nunaliit2-multimedia/src/test/resources/multimedia.properties.example
+++ b/nunaliit2-multimedia/src/test/resources/multimedia.properties.example
@@ -4,7 +4,7 @@
 #ffmpegCreateThumbnailCommand=avconv -y -ss 00:00:05 -i %1$s -s %3$dx%4$d -r 1 -vframes 1 -f image2 %2$s
 #imageInfoCommand=identify -verbose %1$s[0]
 #imageConvertCommand=convert -monitor -auto-orient %1$s[0] -compress JPEG -quality 70 %2$s
-#imageResizeCommand=convert -monitor -auto-orient %1$s[0] -resize %3$dx%4$d> -compress JPEG -quality 70 %2$s
+#imageResizeCommand=convert -monitor -auto-orient %1$s[0] -resize %3$dx%4$d> -compress JPEG -alpha flatten -quality 70 %2$s
 #imageReorientCommand=convert -monitor -auto-orient %1$s[0] %2$s
 #imageMaxHeight=1000
 #imageMaxWidth=1000


### PR DESCRIPTION
Added the command line option -alpha flatten for the ImageMagick convert command.

Fixes the black background thumbnail creation issue when generating pdf
thumbnails.