### PR TITLE
 n2.wiki – Horizontal Rule wiki-markup fix

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.wiki.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.wiki.js
@@ -792,7 +792,8 @@ function WikiToHtml(opts_){
 		
 		// Horizontal Line
 		line = line.replace(/(?:^|\n)([-]+)\s*/g, function (m, l) {
-		    if (l.length > 3) {
+		    var minDashQuantity = 4;
+		    if (l.length >= minDashQuantity) {
 		        return '<hr class="n2wiki"/>';			
 		    } else {
 			return l;

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.wiki.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.wiki.js
@@ -791,8 +791,12 @@ function WikiToHtml(opts_){
 	    });
 		
 		// Horizontal Line
-		line = line.replace(/(?:^|\n)([-]+)\s*/g, function (m) {
-	        return '<hr class="n2wiki"/>';
+		line = line.replace(/(?:^|\n)([-]+)\s*/g, function (m, l) {
+		    if (l.length > 3) {
+		        return '<hr class="n2wiki"/>';			
+		    } else {
+			return l;
+		    };
 	    });
 
 		// Links


### PR DESCRIPTION
After testing when a horizontal rule is created with wiki-markup in
wikipedia, hr appear to only be generated when 4 or more dash
characters are placed independently on a new line, with no additional
characters added before or after the series of dashes. This update fixes the issue of "-", "--" and "---" being converted to hr tags
