### PR TITLE
Added the 'n2-' prefix to the list of valid attributes

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.wiki.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.wiki.js
@@ -628,6 +628,9 @@ function insertShowService(links){
 		} else if( 'nunaliit-' === name.substr(0,'nunaliit-'.length) ){
 			// Allow nunaliit specific attributes
 			validAttribute = true;
+		} else if( 'n2-' === name.substr(0,'n2-'.length) ){
+			// Allow n2 specific attributes
+			validAttribute = true;
 		} else if( $n2.html.isAttributeNameValid(name) ){
 			validAttribute = true;
 		};


### PR DESCRIPTION
#512 Added n2- prefix to the list of valid attributes types when inserting a
show service into a wiki document. 

This is needed when using the n2s_insertDocumentList show service in
wiki documents which uses n2-list-name and n2-list-type as it's required
attribute names.