### PR TITLE
Pre-fix Update _handleDocumentListResults to allow 'nunaliit-' and added support for mailto: external links

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchShow.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchShow.js
@@ -1863,8 +1863,18 @@ var Show = $n2.Class({
 		
 		$('.n2show_documentList_wait').each(function(){
 			var $elem = $(this);
-			var listType = $elem.attr('n2-list-type');
-			var listName = $elem.attr('n2-list-name');
+			
+			var listType = $elem.attr('nunaliit-list-type');
+			if( typeof listType === 'undefined'){
+				listType = $elem.attr('n2-list-type');
+			};
+			var listName = $elem.attr('nunaliit-list-name');
+			if( typeof listName === 'undefined'){
+				listName = $elem.attr('n2-list-name');
+			};
+			
+			//var listType = $elem.attr('n2-list-type');
+			//var listName = $elem.attr('n2-list-name');
 			
 			if( listType === m.listType 
 			 && listName === m.listName ){

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchShow.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchShow.js
@@ -1873,9 +1873,6 @@ var Show = $n2.Class({
 				listName = $elem.attr('n2-list-name');
 			};
 			
-			//var listType = $elem.attr('n2-list-type');
-			//var listName = $elem.attr('n2-list-name');
-			
 			if( listType === m.listType 
 			 && listName === m.listName ){
 				$elem

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.wiki.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.wiki.js
@@ -656,7 +656,8 @@ function computeLink(linkText){
 	var url = links[0];
 	var docId = undefined;
 	if( 'http://' === url.substr(0,'http://'.length)
-	 || 'https://' === url.substr(0,'https://'.length) ){
+	 || 'https://' === url.substr(0,'https://'.length) 
+	 || 'mailto:' === url.substr(0,'mailto:'.length)){
 		externalLink = true;
 
 	} else if( 'nunaliit:' === url.substr(0,'nunaliit:'.length) ){
@@ -744,10 +745,11 @@ function computeLink(linkText){
 // ----
 //
 // Links:
-// [[http://abc.com | description]]   External link
-// [[https://abc.com | description]]  External link
-// [[docId | description]]            Internal link
-// [[nunaliit:class | option]]        Show service insert
+// [[http://abc.com | description]]   		External link
+// [[https://abc.com | description]]  		External link
+// [[mailto:name@abc.com | description]]	External link
+// [[docId | description]]            		Internal link
+// [[nunaliit:class | option]]        		Show service insert
 //
 // Styling:
 // ''italics''


### PR DESCRIPTION
#512 Added pre-fix code to the _handleDocumentListResults function to include a condition for 'nunaliit-' list-type and list-name attributes. 