### PR TITLE
Added showRangeSlider option to timeline widget

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
@@ -457,7 +457,7 @@ Timeline widget
 }
 
 .n2timeline .n2timeline_slider {
-	background-color: #000000;
+	background-color: #ffffff;
 }
 
 .n2timeline .n2timeline_slider .ui-slider-range {

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.widgetTime.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.widgetTime.js
@@ -105,6 +105,8 @@ var TimelineWidget = $n2.Class({
 
 	intervalSetEventName: null,
 	
+	showRangeSlider: null,
+	
 	rangeMin: null,
 	
 	rangeMax: null,
@@ -118,12 +120,14 @@ var TimelineWidget = $n2.Class({
 			containerId: null
 			,dispatchService: null
 			,sourceModelId: null
+			,showRangeSlider: true
 		},opts_);
 		
 		var _this = this;
 		
 		this.dispatchService = opts.dispatchService;
 		this.sourceModelId = opts.sourceModelId;
+		this.showRangeSlider = opts.showRangeSlider;
 		
 		this.rangeMin = null;
 		this.rangeMax = null;
@@ -221,15 +225,25 @@ var TimelineWidget = $n2.Class({
 					.addClass('n2timeline_slider')
 					.appendTo($sliderWrapper);
 
-				$slider.slider({
-					range: true
-					,min: this.rangeMin
-					,max: this.rangeMax
-					,values: [this.intervalMin, this.intervalMax]
-					,slide: function(event, ui){
-						_this._barUpdated(ui);
-					}
-				});
+                if( this.showRangeSlider ){
+					$slider.slider({
+						range: true
+						,min: this.rangeMin
+						,max: this.rangeMax
+						,values: [this.intervalMin, this.intervalMax]
+						,slide: function(event, ui){
+							_this._barUpdated(ui);
+						}
+					});
+				} else {
+	                $slider.slider({
+                        min: this.rangeMin
+                        ,max: this.rangeMax
+                        ,slide: function(event, ui){
+                            _this._barUpdated(ui);
+                        }
+                    });
+				};
 			};
 		};
 		return $slider;
@@ -261,8 +275,7 @@ var TimelineWidget = $n2.Class({
 
 		// Create slider
 		this._getSlider();
-
-		this._displayRange();
+        this._displayRange();
 		this._displayInterval();
 	},
 

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.widgetTime.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.widgetTime.js
@@ -120,14 +120,19 @@ var TimelineWidget = $n2.Class({
 			containerId: null
 			,dispatchService: null
 			,sourceModelId: null
-			,showRangeSlider: true
+			,showRangeSlider: null
 		},opts_);
 		
 		var _this = this;
 		
 		this.dispatchService = opts.dispatchService;
 		this.sourceModelId = opts.sourceModelId;
-		this.showRangeSlider = opts.showRangeSlider;
+
+		if( typeof opts.showRangeSlider === 'boolean' ){
+			this.showRangeSlider = opts.showRangeSlider;
+		} else {
+			this.showRangeSlider = true;
+		};
 		
 		this.rangeMin = null;
 		this.rangeMax = null;
@@ -225,7 +230,7 @@ var TimelineWidget = $n2.Class({
 					.addClass('n2timeline_slider')
 					.appendTo($sliderWrapper);
 
-                if( this.showRangeSlider ){
+				if( this.showRangeSlider ){
 					$slider.slider({
 						range: true
 						,min: this.rangeMin
@@ -236,13 +241,13 @@ var TimelineWidget = $n2.Class({
 						}
 					});
 				} else {
-	                $slider.slider({
-                        min: this.rangeMin
-                        ,max: this.rangeMax
-                        ,slide: function(event, ui){
-                            _this._barUpdated(ui);
-                        }
-                    });
+					$slider.slider({
+						min: this.rangeMin
+						,max: this.rangeMax
+						,slide: function(event, ui){
+							_this._barUpdated(ui);
+						}
+					});
 				};
 			};
 		};
@@ -275,7 +280,8 @@ var TimelineWidget = $n2.Class({
 
 		// Create slider
 		this._getSlider();
-        this._displayRange();
+
+        	this._displayRange();
 		this._displayInterval();
 	},
 


### PR DESCRIPTION
Provided an option to show/hide the dual handle timeline slider. By default the this option is set to true but if the showRangeSlider option is set to false in the timeline widget, the dual handle slider will be replaced with a single handle. 

This addresses issue #601 