### PR TITLE
Single Handle timeline widget addition

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
@@ -464,6 +464,10 @@ Timeline widget
 	background-color: #ffffff;
 }
 
+.n2timeline .n2timeline_slider .n2timeline_slider_left_slider_hidden {
+	display: none;
+}
+
 .n2timeline_range {
 	width: 100%;
 	font-size: 12px;

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.widgetTime.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.widgetTime.js
@@ -105,6 +105,8 @@ var TimelineWidget = $n2.Class({
 
 	intervalSetEventName: null,
 	
+	showSingleHandle: null,
+	
 	rangeMin: null,
 	
 	rangeMax: null,
@@ -118,12 +120,19 @@ var TimelineWidget = $n2.Class({
 			containerId: null
 			,dispatchService: null
 			,sourceModelId: null
+			,showSingleHandle: null
 		},opts_);
 		
 		var _this = this;
 		
 		this.dispatchService = opts.dispatchService;
 		this.sourceModelId = opts.sourceModelId;
+
+		if( typeof opts.showSingleHandle === 'boolean' ){
+			this.showSingleHandle = opts.showSingleHandle;
+		} else {
+			this.showSingleHandle = false;
+		};
 		
 		this.rangeMin = null;
 		this.rangeMax = null;
@@ -230,6 +239,27 @@ var TimelineWidget = $n2.Class({
 						_this._barUpdated(ui);
 					}
 				});
+				
+				if (this.showSingleHandle) {
+
+					// Update the date interval 
+					var value = new $n2.date.DateInterval({
+						min: this.rangeMin
+						,max: this.rangeMin
+						,ongoing: false
+					});
+
+					this.dispatchService.send(DH,{
+						type: this.intervalSetEventName
+						,value: value
+					});
+
+					// Hide first slider handle
+					var $sliderHandle = $('.n2timeline_slider .ui-slider-handle');
+					if ($sliderHandle.length > 1) {
+						$sliderHandle.first().addClass('n2timeline_slider_left_slider_hidden');
+					};					
+				};
 			};
 		};
 		return $slider;
@@ -238,7 +268,7 @@ var TimelineWidget = $n2.Class({
 	_removeSlider: function(){
 		$('#'+this.elemId).find('.n2timeline_slider_wrapper').empty();
 	},
-	
+
 	_display: function(){
 		var $elem = this._getElem()
 			.empty();
@@ -262,7 +292,7 @@ var TimelineWidget = $n2.Class({
 		// Create slider
 		this._getSlider();
 
-		this._displayRange();
+        	this._displayRange();
 		this._displayInterval();
 	},
 


### PR DESCRIPTION
Provided an option to replace the dual handle timeline slider. By default the this new option is set to false but if the showSingleHandle option is set to true in the timeline widget, the dual handle slider will be replaced with a single handle.

A timeline with a single time-slider handle will initially have a interval set to the minimum range, allowing the user to move the handle to expose more items on the map, as you move through the time range.

This addresses issue #601

Note: This is the same code as before, I just moved it to a separate branch. 