### PR TITLE
Legend widget update

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
@@ -691,26 +691,40 @@ Map Legend
 }
 
 .nunaliit_content > .n2widgetLegend .n2widgetLegend_outer {
-	background-color: #000;
+	background-color: rgba(0,0,0,0.9);
 	color: #fff;
 	padding: 10px;
-	border-radius: 5px;
-    border-color: #fff;
-    border-width: 1px;
-    border-style: solid;
-    box-shadow: 3px 3px 3px 0 rgba(0,0,0, 0.25);
+	border-radius: 2px;
+	border: 1px solid #FFFFFF;
+    box-shadow: 3px 3px 3px 0 rgba(0,0,0,0.25);
 }
 
-.nunaliit_content > .n2widgetLegend .n2widgetLegend_labelEntry::after {
-	content: "";
-	display: block;
-	clear: both;
+.nunaliit_content > .n2widgetLegend .n2widgetLegend_outer .n2widgetLegend_labelColumn {
+	width: auto;
+	max-width: 300px;
+	display: inline-block;
+	vertical-align: top;
 }
 
-.nunaliit_content > .n2widgetLegend .n2widgetLegend_preview {
+.nunaliit_content > .n2widgetLegend .n2widgetLegend_outer .n2widgetLegend_symbolColumn {
+	width: 70px;
+	display: inline-block;
+}
+
+.n2widgetLegend_symbolColumn_point,
+.n2widgetLegend_symbolColumn_line,
+.n2widgetLegend_symbolColumn_polygon,
+.n2widgetLegend_symbolColumn_cluster {
 	float: left;
 }
 
+/* Add padding to legend widget symbols */
+.n2widgetLegend_symbolColumn_point .n2widgetLegend_preview.n2widgetLegend_previewPoint,
+.n2widgetLegend_symbolColumn_line .n2widgetLegend_preview.n2widgetLegend_previewLine,
+.n2widgetLegend_symbolColumn_polygon .n2widgetLegend_preview.n2widgetLegend_previewPolygon,
+.n2widgetLegend_symbolColumn_cluster .n2widgetLegend_preview.n2widgetLegend_previewCluster {
+	padding: 1px;
+}
 
 /* 
 ==============================

--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
@@ -696,7 +696,7 @@ Map Legend
 	padding: 10px;
 	border-radius: 2px;
 	border: 1px solid #FFFFFF;
-    box-shadow: 3px 3px 3px 0 rgba(0,0,0,0.25);
+	box-shadow: 3px 3px 3px 0 rgba(0,0,0,0.25);
 }
 
 .nunaliit_content > .n2widgetLegend .n2widgetLegend_outer .n2widgetLegend_labelColumn {

--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
@@ -707,7 +707,7 @@ Map Legend
 }
 
 .nunaliit_content > .n2widgetLegend .n2widgetLegend_outer .n2widgetLegend_symbolColumn {
-	width: 70px;
+	width: 70px; /* width needed to contain four legend symbols */
 	display: inline-block;
 }
 

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.widgetLegend.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.widgetLegend.js
@@ -151,7 +151,7 @@ var LegendWidget = $n2.Class('LegendWidget',{
 			var $outer = $('<div>')
 				.addClass('n2widgetLegend_outer')
 				.appendTo($elem);
-
+		
 			var labelNames = [];
 			for(var labelName in stylesByLabel){
 				labelNames.push(labelName);
@@ -162,13 +162,37 @@ var LegendWidget = $n2.Class('LegendWidget',{
 				var labelInfo = stylesByLabel[labelName];
 
 				var $div = $('<div>')
-					.addClass('n2widgetLegend_labelEntry')
+					.addClass('n2widgetLegend_legendEntry')
 					.appendTo($outer);
-			
-				$('<div>')
-					.addClass('n2widgetLegend_labelName')
-					.text(labelName)
+
+				var $symbolColumn = $('<div>')
+					.addClass('n2widgetLegend_symbolColumn')
 					.appendTo($div);
+				
+				var $symbolColumnPoint = $('<div>')
+					.addClass('n2widgetLegend_symbolColumn_point')
+					.appendTo($symbolColumn);				
+				
+				var $symbolColumnLine = $('<div>')
+					.addClass('n2widgetLegend_symbolColumn_line')
+					.appendTo($symbolColumn);				
+				
+				var $symbolColumnPolygon = $('<div>')
+					.addClass('n2widgetLegend_symbolColumn_polygon')
+					.appendTo($symbolColumn);
+				
+				var $symbolColumnCluster = $('<div>')
+					.addClass('n2widgetLegend_symbolColumn_cluster')
+					.appendTo($symbolColumn);
+
+				var $labelColumn = $('<div>')
+					.addClass('n2widgetLegend_labelColumn')
+					.appendTo($div);
+
+				$('<div>')
+					.addClass('n2widgetLegend_labelEntry')
+					.text(labelName)
+					.appendTo($labelColumn);
 				
 				var styleIds = [];
 				for(var styleId in labelInfo){
@@ -179,12 +203,19 @@ var LegendWidget = $n2.Class('LegendWidget',{
 				styleIds.forEach(function(styleId){
 					var styleInfo = labelInfo[styleId];
 					var style = styleInfo.style;
-
-					if( styleInfo.point ){
+					
+					// Check if point is a cluster and create either a point or cluster symbol
+					if( styleInfo.point && styleInfo.point.cluster && styleInfo.point.cluster.length > 1 ){
+						var $preview = $('<div>')
+							.addClass('n2widgetLegend_preview n2widgetLegend_previewCluster')
+							.attr('n2-style-id',style.id)
+							.appendTo($symbolColumnCluster);
+						_this._insertSvgPreviewPoint($preview, style, styleInfo.point);
+					} else if( styleInfo.point ){
 						var $preview = $('<div>')
 							.addClass('n2widgetLegend_preview n2widgetLegend_previewPoint')
 							.attr('n2-style-id',style.id)
-							.appendTo($div);
+							.appendTo($symbolColumnPoint);
 						_this._insertSvgPreviewPoint($preview, style, styleInfo.point);
 					};
 
@@ -192,7 +223,7 @@ var LegendWidget = $n2.Class('LegendWidget',{
 						var $preview = $('<div>')
 							.addClass('n2widgetLegend_preview n2widgetLegend_previewLine')
 							.attr('n2-style-id',style.id)
-							.appendTo($div);
+							.appendTo($symbolColumnLine);
 						_this._insertSvgPreviewLine($preview, style, styleInfo.line);
 					};
 
@@ -200,7 +231,7 @@ var LegendWidget = $n2.Class('LegendWidget',{
 						var $preview = $('<div>')
 							.addClass('n2widgetLegend_preview n2widgetLegend_previewPolygon')
 							.attr('n2-style-id',style.id)
-							.appendTo($div);
+							.appendTo($symbolColumnPolygon);
 						_this._insertSvgPreviewPolygon($preview, style, styleInfo.polygon);
 					};
 				});


### PR DESCRIPTION
Updated the layout of the legend from a stacked apperance with symbols below labels, with a multi-column layout with symbols on the left and labels on right. See screenshot comparison below (left: original layout, right:proposed layout change). 

![legendlayoutupdate](https://cloud.githubusercontent.com/assets/6431161/25352325/a9123d88-28f9-11e7-8136-4c5880ef37d5.png)

Note: symbols were given the order of  points, lines, polygons, and lastly clusters.