### PR TITLE
Multi select filter style update

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
@@ -682,7 +682,7 @@ Multi Drop Down Filter Selection
 
 .nunaliit_module_title .n2widget_multiDropDownFilterSelection {
 	float: right;
-	padding: 8px 20px;
+	padding: 4px 10px;
 }
 
 .n2widget_multiDropDownFilterSelection_position {
@@ -696,16 +696,30 @@ Multi Drop Down Filter Selection
 	padding: 0;
 }
 
+.n2widget_multiDropDownFilterSelection_selection_hidden button::after {
+	content:"\25be";
+	padding-left: 5px;
+}
+
+.n2widget_multiDropDownFilterSelection_selection_shown button::after {
+	content:"\25b4";
+	padding-left: 5px;
+}
+
 .n2widget_multiDropDownFilterSelection_selection_hidden .n2widget_multiDropDownFilterSelection_position {
 	display: none;
 }
 
 .n2widget_multiDropDownFilterSelection_select {
+	max-height: 355px;
+    height: auto;
 	min-width: 260px;
     margin-top: 1px;
     border-top: none;
     color: #000;
     background-color: #fff;
+    overflow-y: auto;
+    box-shadow: 0px 1px 15px #aaaaaa, 0px 1px 1px #666666;
 }
 
 .n2widget_multiDropDownFilterSelection_option a {
@@ -717,10 +731,37 @@ Multi Drop Down Filter Selection
     cursor: pointer;  
 }
 
-.n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionSelected {
-    background-color: #fcc;
+.n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionUnselected {
+	background-color: #f9f9f9;
 }
 
+.n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionSelected {
+	background-color: #ffffff;
+}
+
+.n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionUnselected a,
+.n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionSelected a {
+    padding: 5px 0px 5px 10px;
+}
+
+.n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionSelected a {
+    color: #111111 !important;
+}
+
+.n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionUnselected a {
+    color: #aaaaaa !important;
+}
+
+.n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionUnselected a::before {
+	content:"\2610";
+	padding-right: 5px;
+}
+
+.n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionSelected a::before {
+	content:"\2611";
+	padding-right: 5px;
+	font-weight: bold;
+}
 
 /* 
 ==============================

--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
@@ -686,7 +686,7 @@ Multi Drop Down Filter Selection
 }
 
 .n2widget_multiDropDownFilterSelection_position {
-	position: 'absolute';
+	position: absolute;
 	left: 0;
 	bottom: 0;
 	width: 0;
@@ -712,23 +712,23 @@ Multi Drop Down Filter Selection
 
 .n2widget_multiDropDownFilterSelection_select {
 	max-height: 355px;
-    height: auto;
+	height: auto;
 	min-width: 260px;
-    margin-top: 1px;
-    border-top: none;
-    color: #000;
-    background-color: #fff;
-    overflow-y: auto;
-    box-shadow: 0px 1px 15px #aaaaaa, 0px 1px 1px #666666;
+	margin-top: 1px;
+	border-top: none;
+	color: #000;
+	background-color: #fff;
+	overflow-y: auto;
+	box-shadow: 0px 1px 15px #aaaaaa, 0px 1px 1px #666666;
 }
 
 .n2widget_multiDropDownFilterSelection_option a {
-    color: #000;
+	color: #000;
 	padding: 12px 0px 10px 24px;
 	display: block;
-    clear: both;
-    white-space: nowrap;
-    cursor: pointer;  
+	clear: both;
+	white-space: nowrap;
+	cursor: pointer;  
 }
 
 .n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionUnselected {
@@ -741,15 +741,15 @@ Multi Drop Down Filter Selection
 
 .n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionUnselected a,
 .n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionSelected a {
-    padding: 5px 0px 5px 10px;
+	padding: 5px 0px 5px 10px;
 }
 
 .n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionSelected a {
-    color: #111111 !important;
+	color: #111111 !important;
 }
 
 .n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionUnselected a {
-    color: #aaaaaa !important;
+	color: #aaaaaa !important;
 }
 
 .n2widget_multiDropDownFilterSelection_option.n2widget_multiDropDownFilterSelection_optionUnselected a::before {


### PR DESCRIPTION
Updated default appearance of multi-selection filter.

**Overview of Changes:** 
- Removed pink selected option colour with simple white background with dark foreground
- Added unselected styling shown as slight grey background and greyed out foreground
- Added unchecked-box (when not selected) and checked-box (when selected) unicode character to option labels 
- Added a down arrow and up arrow to button label (depends on if the filter options are shown or not)
- Adjusted button default padding
- Selection window updated with box shadow and border-radius