### PR TITLE
Added support for the OpenLayers ScaleLine Control

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.openlayers.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.openlayers.css
@@ -71,8 +71,8 @@ div.olControlMousePosition {
 
 .olControlScaleLine {
 	background-color: rgba(255,255,255,0.7);
-    padding: 2px 5px;
-    bottom: 18px;
-    right: 0;
-    left: auto;
+	padding: 2px 5px;
+	bottom: 18px;
+	right: 0;
+	left: auto;
 }

--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.openlayers.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.openlayers.css
@@ -54,3 +54,25 @@ div.olControlMousePosition {
 	right: 25px;
 	background: rgba(255, 255, 255, 0.7) !important;
 }*/
+
+.olControlAttribution {
+	background-color: rgba(255,255,255,0.7);
+	padding: 2px;
+	bottom: 0;
+	right: 125px;
+}
+
+.olControlMousePosition {
+	bottom: 0;
+	right: 0 !important;
+	padding: 2px;
+	background: rgba(255, 255, 255, 0.7);
+}
+
+.olControlScaleLine {
+	background-color: rgba(255,255,255,0.7);
+    padding: 2px 5px;
+    bottom: 18px;
+    right: 0;
+    left: auto;
+}

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchModule.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchModule.js
@@ -1003,6 +1003,15 @@ var ModuleDisplay = $n2.Class({
 		};
 		
 		// Enable wheel zoom
+		var scaleLine = {
+			visible: false
+		};
+
+		if( mapInfo && mapInfo.scaleLine && mapInfo.scaleLine.visible ){
+			scaleLine = mapInfo.scaleLine;
+		};
+
+		// Enable wheel zoom
 		var enableWheelZoom = false;
 		if( mapInfo && mapInfo.enableWheelZoom ){
 			enableWheelZoom = true;
@@ -1034,6 +1043,7 @@ var ModuleDisplay = $n2.Class({
 			,addPointsOnly: addPointsOnly
 			,overlays: []
 			,toggleClick: toggleClick
+			,scaleLine: scaleLine
 			,enableWheelZoom: enableWheelZoom
 			,sidePanelName: _this.sidePanelName
 			,filterPanelName: _this.filterPanelName

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchModule.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchModule.js
@@ -1002,7 +1002,7 @@ var ModuleDisplay = $n2.Class({
 			toggleClick = mapInfo.toggleClick;
 		};
 		
-		// Enable wheel zoom
+		// ScaleLine
 		var scaleLine = {
 			visible: false
 		};

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.mapAndControls.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.mapAndControls.js
@@ -859,7 +859,10 @@ var LayerInfo = $n2.Class({
     
 		{Boolean} addPointsOnly=false
     	If true, editing the map can only add points.
-    
+	
+		{Object} scaleLine
+    	Defines properties for the scale line control
+
 		{Boolean} enableWheelZoom=false
     	If true, mouse wheel zooms in and out.
     
@@ -1066,6 +1069,9 @@ var MapAndControls = $n2.Class({
 				,units: 'm' // map units
 			}
 			,addPointsOnly: false
+			,scaleLine: {
+				visible: false
+			}
 			,enableWheelZoom: false
 			,placeDisplay: { // place info panel display options.
 				attribDisplayType: 'attributes' // default - just list the attributes in a table	
@@ -1447,6 +1453,29 @@ var MapAndControls = $n2.Class({
 			,zoomMethod: null  // Zoom with features does not look good
 		});
 		
+		// Create Scale line 
+		if( this.options.scaleLine && this.options.scaleLine.visible ){
+			// Default OpenLayers Scale Line Properties:
+			// ------------------------------------
+			// bottomOutUnits: mi
+			// bottomInUnits: ft
+			// topOutUnits: km
+			// topInUnits: m
+			// maxWidth: 100 (in pixels)
+			// geodesic: false
+
+			var scaleLine = new OpenLayers.Control.ScaleLine({
+				bottomOutUnits: this.options.scaleLine.bottomOutUnits
+				,bottomInUnits: this.options.scaleLine.bottomInUnits
+				,topOutUnits: this.options.scaleLine.topOutUnits
+				,topInUnits: this.options.scaleLine.topInUnits
+				,maxWidth: this.options.scaleLine.maxWidth
+				,geodesic: this.options.scaleLine.geodesic
+			});
+
+			this.map.addControl(scaleLine);
+		};
+
 		// Disable zoom on mouse wheel
 		if( this.options.enableWheelZoom ) {
 			// Do nothing. Enabled by default


### PR DESCRIPTION
Added support for the [ScaleLine Control](http://dev.openlayers.org/docs/files/OpenLayers/Control/ScaleLine-js.html) for Nunaliit. See screenshot below. 
 
If this request is accepted, I'll add documentation to the wiki on how users can enable it (disabled by default). 

![scalelinecontrol](https://user-images.githubusercontent.com/6431161/32747110-c2148076-c885-11e7-8eca-15ac9bed8107.png)

Note: I've also included style changes for the attribution and mouse position controls (previously created in another branch containing style updates). 