### PR TITLE
Fixed typeErrors in Collapsible Radia Tree Canvas

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.canvasCollapsibleRadialTree.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.canvasCollapsibleRadialTree.js
@@ -1022,7 +1022,9 @@ var CollapsibleRadialTreeCanvas = $n2.Class({
  		this.elementsById = {};
  		this.elementsByDocId = {};
  		this.effectiveElementsById = {};
- 		this.elementToEffectiveId = {};
+		this.elementToEffectiveId = {};
+		this.elementTreeRoot = {};
+		this.sourceLinks = [];
  		this.dimensions = {};
  		this.lastElementIdSelected = null;
  		this.focusInfo = null;
@@ -1474,7 +1476,6 @@ var CollapsibleRadialTreeCanvas = $n2.Class({
 			,children: []
 			,expanded: true
 		};
-		this.sourceLinks = [];
 		for(var elemId in this.elementsById){
 			var elem = this.elementsById[elemId];
 			

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.canvasCollapsibleRadialTree.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.canvasCollapsibleRadialTree.js
@@ -1476,6 +1476,7 @@ var CollapsibleRadialTreeCanvas = $n2.Class({
 			,children: []
 			,expanded: true
 		};
+		this.sourceLinks = [];
 		for(var elemId in this.elementsById){
 			var elem = this.elementsById[elemId];
 			


### PR DESCRIPTION
fixes #726 

Note: Made a minor correction of re-adding an empty this.sourceLinks array. This resets the contents and prevents re-adding already existing links to the array after a change.  