### PR TITLE
Updated field names with an underscore prefix

### DIFF
--- a/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/schema/SchemaAttribute.java
+++ b/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/schema/SchemaAttribute.java
@@ -495,13 +495,13 @@ public class SchemaAttribute {
 				doc.put("nunaliit_attachments", attachments);
 			}
             if( null != maxAudioRecordingLengthSeconds && maxAudioRecordingLengthSeconds.intValue() > 0 ){
-                doc.put("_maxAudioRecordingLengthSeconds", maxAudioRecordingLengthSeconds);
+                doc.put("nunaliit_maxAudioRecordingLengthSeconds", maxAudioRecordingLengthSeconds);
             }
 			if( null != maxVideoRecordingLengthSeconds && maxVideoRecordingLengthSeconds.intValue() > 0 ){
-				doc.put("_maxVideoRecordingLengthSeconds", maxVideoRecordingLengthSeconds);
+				doc.put("nunaliit_maxVideoRecordingLengthSeconds", maxVideoRecordingLengthSeconds);
 			}
 			if( null != recordVideoSize ){
-				doc.put("_recordVideoSize", recordVideoSize);
+				doc.put("nunaliit_recordVideoSize", recordVideoSize);
 			}
 
 			JSONObject files = attachments.getJSONObject("files");

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchEdit.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchEdit.js
@@ -2644,18 +2644,18 @@ var AttachmentEditor = $n2.Class({
 		//load configuration
 		if( this.doc
 			&& !this.doc._rev) {
-			if(typeof this.doc._maxAudioRecordingLengthSeconds !== 'undefined') {
-				this.maxAudioRecordingLengthSeconds = this.doc._maxAudioRecordingLengthSeconds;
-				delete this.doc._maxAudioRecordingLengthSeconds;
+			if(typeof this.doc.nunaliit_maxAudioRecordingLengthSeconds !== 'undefined') {
+				this.maxAudioRecordingLengthSeconds = this.doc.nunaliit_maxAudioRecordingLengthSeconds;
+				delete this.doc.nunaliit_maxAudioRecordingLengthSeconds;
 			}
-			if(typeof this.doc._maxVideoRecordingLengthSeconds !== 'undefined') {
-				this.maxVideoRecordingLengthSeconds = this.doc._maxVideoRecordingLengthSeconds;
-				delete this.doc._maxVideoRecordingLengthSeconds;
+			if(typeof this.doc.nunaliit_maxVideoRecordingLengthSeconds !== 'undefined') {
+				this.maxVideoRecordingLengthSeconds = this.doc.nunaliit_maxVideoRecordingLengthSeconds;
+				delete this.doc.nunaliit_maxVideoRecordingLengthSeconds;
 			}
-			if(typeof this.doc._recordVideoSize !== 'undefined') {
-				var videoSizeParts = this.doc._recordVideoSize.split('x');
+			if(typeof this.doc.nunaliit_recordVideoSize !== 'undefined') {
+				var videoSizeParts = this.doc.nunaliit_recordVideoSize.split('x');
 				this.recordVideoSize = {width: videoSizeParts[0], height: videoSizeParts[1]};
-				delete this.doc._recordVideoSize;
+				delete this.doc.nunaliit_recordVideoSize;
 			}
 		}
 


### PR DESCRIPTION
fix #731 

Underscore prefixes are reserved by CouchDB in a document's top-level. See [CouchDB Wiki](https://wiki.apache.org/couchdb/HTTP_Document_API#Special_Fields).