### PR TITLE
Added viewport meta tag to index.html

### DIFF
--- a/nunaliit2-couch-sdk/src/main/content/htdocs/index.html
+++ b/nunaliit2-couch-sdk/src/main/content/htdocs/index.html
@@ -13,6 +13,7 @@
 		<meta name="dc.format" content="html" /> 
 		<meta name="dc.rights" content="Materials are under copyright. Contact admin@gcrc.carleton.ca" /> 
 		<meta name="dc.type" content="Interactive Resource" />
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		
 		<title>Atlas</title>
 


### PR DESCRIPTION
Included viewport meta tag to index.html to allow page content to be responsive to the device width, instead of the default page width. 