### PR TITLE
Added table row counter to table canvas.

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.canvasTable.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.canvasTable.css
@@ -12,3 +12,12 @@
 .n2TableCanvas td.n2TableCanvas_lazyDisplay {
     height: 10px;
 }
+
+/* Table Row Counter */
+.n2TableCanvas .n2TableCanvasRowCounter {
+	display: inline;
+    border: 1px solid #999999;
+    border-radius: 2px;
+    margin: 9px 5px 9px 0px;
+    padding: 2px 5px;
+}

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.canvasTable.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.canvasTable.js
@@ -312,7 +312,9 @@ var TableCanvas = $n2.Class({
 	styleRules: null,
 	
 	useLazyDisplay: null,
-	
+
+	showRowCount: null,
+
 	refreshIntervalInMs: null,
 
 	initialize: function(opts_){
@@ -321,6 +323,7 @@ var TableCanvas = $n2.Class({
 			,sourceModelId: null
 			,elementGenerator: null
 			,useLazyDisplay: false
+			,showRowCount: false
 			,refreshIntervalInMs: 200
 			,styleRules: null
 			,dispatchService: null
@@ -336,6 +339,7 @@ var TableCanvas = $n2.Class({
 		this.sourceModelId = opts.sourceModelId;
 		this.elementGenerator = opts.elementGenerator;
 		this.useLazyDisplay = opts.useLazyDisplay;
+		this.showRowCount = opts.showRowCount;
 		this.refreshIntervalInMs = opts.refreshIntervalInMs;
 		this.dispatchService = opts.dispatchService;
 		this.showService = opts.showService;
@@ -426,7 +430,29 @@ var TableCanvas = $n2.Class({
 		};
 		return $elem;
 	},
- 	
+	
+	_getTableRowCount: function(){
+		var nunaliitRows = $('tbody tr[nunaliit-row]');
+
+		return nunaliitRows.length;
+	},
+
+	_displayRowCounter: function(){
+		var numRows = this._getTableRowCount();
+		var $tableCanvas = $('.n2TableCanvas');
+		if ($tableCanvas.length) {
+			if (!$('.n2TableCanvasRowCounter').length) {
+				$('<div>')
+					.addClass('n2TableCanvasRowCounter')
+					.prependTo($tableCanvas);
+			}
+
+			// Add/Update number of rows text
+			$('.n2TableCanvasRowCounter')
+				.text(numRows + ' ' + _loc('rows'));
+		}
+	},
+
  	createGraph: function() {
 		var _this = this;
 		
@@ -643,6 +669,10 @@ var TableCanvas = $n2.Class({
 				};
 			});
 		});
+
+		if( this.showRowCount ){
+			this._displayRowCounter();
+		}
 
 		if( this.useLazyDisplay ){
 			this._refreshRows();


### PR DESCRIPTION
Adds a row counter above the table canvas (next to export button), which can be turned on by setting the canvas.json property showRowCount to true.

