### PR TITLE
Fix the d-key bug, which case the console log error when typing lowercase d in form view

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.mapAndControls.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.mapAndControls.js
@@ -2147,6 +2147,7 @@ var MapAndControls = $n2.Class({
    				'displayClass': 'olControlMoveFeature'
    				,standalone: true
    				,clickout: false
+   				,deleteCodes : [46]
    			}
    		);
    		modifyFeatureGeometry.mode = OpenLayers.Control.ModifyFeature.RESHAPE;


### PR DESCRIPTION
Lowercase d is the default deleteing code for ol2, but it can conflict with nunaliit form editor when user intentionally want to type d in the input field