### PR TITLE
Fixed issue with initialSelection not updating visibility of initially selected documents

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.modelFilter.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.modelFilter.js
@@ -1039,6 +1039,9 @@ var SelectableDocumentFilter = $n2.Class('SelectableDocumentFilter', {
 						// Is not visible and did not used to be visible: nothing
 					};
 				};
+				
+				// Update visibility
+				docInfo.visible = visible;
 			};
 		};
 		


### PR DESCRIPTION
**Solution**: Added an update to the visibility of the docInfo in the source model update when a document is added (previously only occurring when a document is updated).

fix #837