### PR TITLE
Overwrote user agent style sheet rules for filter widgets when in the…

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
+++ b/nunaliit2-js/src/main/js/nunaliit2/css/basic/n2.widget.css
@@ -640,6 +640,11 @@ Single Filter Selection
 	padding: 4px 20px;
 }
 
+.nunaliit_module_title .n2widget_singleFilterSelection select {
+	border-width: 1px;
+	border-radius: 2px;
+	background-color: #F1F1F1;
+}
 /* 
 ==============================
 Multi Filter Selection 
@@ -675,6 +680,13 @@ Multi Drop Down Filter Selection
 	float: right;
 	padding: 4px 10px;
 }
+
+.nunaliit_module_title .n2widget_multiDropDownFilterSelection button {
+	border-width: 1px;
+	border-radius: 2px;
+	background-color: #F1F1F1;
+}
+
 .nunaliit_module_title .n2widget_multiDropDownFilterSelection.n2widget_multiDropDownFilterSelection_asLink {
 	padding: 8px 20px;
 }


### PR DESCRIPTION
module title bar. These style rule tweaks include;

* setting the border-width to 1px,
* setting the border-radius to 2px,
* and setting background-colour to #F1F1F1

With these style changes, the widgets now have consistent colour/shape, which don't
extend beyond the module title bar height. Tested in Firefox (Ubuntu 18.04, OSx, and Windows 10), Chrome (Ubuntu 18.04, OSx, and Windows 10), Safari (OSx), IE11 (Windows 10), and Microsoft Edge (Windows).

Fix #536 