### PR TITLE
fix: translate section content to french

### DIFF
--- a/nunaliit2-couch-application/src/main/updateDocs/help.wiki/nunaliit_help/content/fr.html
+++ b/nunaliit2-couch-application/src/main/updateDocs/help.wiki/nunaliit_help/content/fr.html
@@ -54,8 +54,8 @@
         <div class="table-head" style="width:50%; background-color:#DDDDDD; border:1px solid #999999; display:table-cell; padding:5px 5px;"><strong>Rendu</strong></div>
     </div>
     <div class="table-row" style="display:table-row;">
-		<div class="table-col" style="width:50%; border:1px solid #999999; display:table-cell; padding:5px 5px;">{{ class="abc" | alt="alt text"<br/>Section content<br/>}}<br/></div>
-		<div class="table-col" style="width:50%; border:1px solid #999999; display:table-cell; padding:5px 5px;"><div class="abc" alt="alt text">Section content</div></div>
+		<div class="table-col" style="width:50%; border:1px solid #999999; display:table-cell; padding:5px 5px;">{{ class="abc" | alt="alt text"<br/>Contenu de la section<br/>}}<br/></div>
+		<div class="table-col" style="width:50%; border:1px solid #999999; display:table-cell; padding:5px 5px;"><div class="abc" alt="alt text">Contenu de la section</div></div>
     </div>
 </div>
 


### PR DESCRIPTION
Hello
related to https://github.com/GCRC/nunaliit/issues/843
1. On line 50 the word Sections is the same in french so I did not translate it
2. +3: "Section content" is translated to "Contenu de la section"