### PR TITLE
Issue 846 - Extend selection filter widget functionality

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.widgetSelectableFilter.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.widgetSelectableFilter.js
@@ -80,7 +80,7 @@ var SingleFilterSelectionWidget = $n2.Class('SingleFilterSelectionWidget',{
 	
 	suppressedChoicesMap: null,
 
-	toolTip: null,
+	tooltip: null,
 	
 	/* 
 	 * These are versions of functions that are throttled. These
@@ -100,7 +100,7 @@ var SingleFilterSelectionWidget = $n2.Class('SingleFilterSelectionWidget',{
 			,suppressAllChoices: false
 			,suppressNoChoice: false
 			,suppressChoices: undefined
-			,toolTip: null
+			,tooltip: null
 		},opts_);
 		
 		var _this = this;
@@ -113,10 +113,10 @@ var SingleFilterSelectionWidget = $n2.Class('SingleFilterSelectionWidget',{
 		this.suppressAllChoices = opts.suppressAllChoices;
 		this.suppressNoChoice = opts.suppressNoChoice;
 
-		if (opts.toolTip
-			&& typeof opts.toolTip === 'string'
-			&& opts.toolTip.length) {
-			this.toolTip = opts.toolTip;
+		if (opts.tooltip
+			&& typeof opts.tooltip === 'string'
+			&& opts.tooltip.length) {
+			this.tooltip = opts.tooltip;
 		}
 
 		this.availableChoices = [];
@@ -242,8 +242,8 @@ var SingleFilterSelectionWidget = $n2.Class('SingleFilterSelectionWidget',{
 				_this._selectionChanged();
 			});
 
-		if (this.toolTip) {
-			$selector.attr('title', this.toolTip);
+		if (this.tooltip) {
+			$selector.attr('title', this.tooltip);
 		}
 
 		if( !this.suppressNoChoice ){
@@ -458,7 +458,7 @@ var MultiFilterSelectionWidget = $n2.Class('MultiFilterSelectionWidget',{
 	
 	allChoicesLabel: null,
 
-	toolTip: null,
+	tooltip: null,
 
 	/* 
 	 * These are versions of functions that are throttled. These
@@ -474,7 +474,7 @@ var MultiFilterSelectionWidget = $n2.Class('MultiFilterSelectionWidget',{
 			,showService: null
 			,sourceModelId: null
 			,allChoicesLabel: null
-			,toolTip: null
+			,tooltip: null
 		},opts_);
 		
 		var _this = this;
@@ -484,10 +484,10 @@ var MultiFilterSelectionWidget = $n2.Class('MultiFilterSelectionWidget',{
 		this.sourceModelId = opts.sourceModelId;
 		this.allChoicesLabel = opts.allChoicesLabel;
 
-		if (opts.toolTip
-			&& typeof opts.toolTip === 'string'
-			&& opts.toolTip.length) {
-			this.toolTip = opts.toolTip;
+		if (opts.tooltip
+			&& typeof opts.tooltip === 'string'
+			&& opts.tooltip.length) {
+			this.tooltip = opts.tooltip;
 		}
 		
 		this.availableChoices = [];
@@ -578,8 +578,8 @@ var MultiFilterSelectionWidget = $n2.Class('MultiFilterSelectionWidget',{
 			.appendTo($container);
 		
 
-		if (this.toolTip) {
-			$selector.attr('title', this.toolTip);
+		if (this.tooltip) {
+			$selector.attr('title', this.tooltip);
 		}
 
 		this._throttledAvailableChoicesUpdated();
@@ -786,7 +786,7 @@ var MultiFilterSelectionDropDownWidget = $n2.Class('MultiFilterSelectionDropDown
 
 	showAsLink: null,
 
-	toolTip: null,
+	tooltip: null,
 
 	/* 
 	 * These are versions of functions that are throttled. These
@@ -805,7 +805,7 @@ var MultiFilterSelectionDropDownWidget = $n2.Class('MultiFilterSelectionDropDown
 			,noChoiceLabel: null
 			,label: null
 			,showAsLink: false
-			,toolTip: null
+			,tooltip: null
 		},opts_);
 		
 		var _this = this;
@@ -818,10 +818,10 @@ var MultiFilterSelectionDropDownWidget = $n2.Class('MultiFilterSelectionDropDown
 		this.label = opts.label;
 		this.showAsLink = opts.showAsLink;
 
-		if (opts.toolTip
-			&& typeof opts.toolTip === 'string'
-			&& opts.toolTip.length) {
-			this.toolTip = opts.toolTip;
+		if (opts.tooltip
+			&& typeof opts.tooltip === 'string'
+			&& opts.tooltip.length) {
+			this.tooltip = opts.tooltip;
 		}
 
 		this.availableChoices = [];
@@ -911,8 +911,8 @@ var MultiFilterSelectionDropDownWidget = $n2.Class('MultiFilterSelectionDropDown
 			.addClass('n2widget_multiDropDownFilterSelection n2widget_multiDropDownFilterSelection_selection_hidden')
 			.appendTo($container);
 
-		if (this.toolTip) {
-			$elem.attr('title', this.toolTip);
+		if (this.tooltip) {
+			$elem.attr('title', this.tooltip);
 		}
 		
 		if( this.showAsLink ){

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.widgetSelectableFilter.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.widgetSelectableFilter.js
@@ -79,6 +79,8 @@ var SingleFilterSelectionWidget = $n2.Class('SingleFilterSelectionWidget',{
 	suppressNoChoice: null,
 	
 	suppressedChoicesMap: null,
+
+	toolTip: null,
 	
 	/* 
 	 * These are versions of functions that are throttled. These
@@ -98,6 +100,7 @@ var SingleFilterSelectionWidget = $n2.Class('SingleFilterSelectionWidget',{
 			,suppressAllChoices: false
 			,suppressNoChoice: false
 			,suppressChoices: undefined
+			,toolTip: null
 		},opts_);
 		
 		var _this = this;
@@ -109,7 +112,13 @@ var SingleFilterSelectionWidget = $n2.Class('SingleFilterSelectionWidget',{
 		this.noChoiceLabel = opts.noChoiceLabel;
 		this.suppressAllChoices = opts.suppressAllChoices;
 		this.suppressNoChoice = opts.suppressNoChoice;
-		
+
+		if (opts.toolTip
+			&& typeof opts.toolTip === 'string'
+			&& opts.toolTip.length) {
+			this.toolTip = opts.toolTip;
+		}
+
 		this.availableChoices = [];
 		this.selectedChoices = [];
 		this.selectedChoiceIdMap = {};
@@ -232,6 +241,10 @@ var SingleFilterSelectionWidget = $n2.Class('SingleFilterSelectionWidget',{
 			.change(function(){
 				_this._selectionChanged();
 			});
+
+		if (this.toolTip) {
+			$selector.attr('title', this.toolTip);
+		}
 
 		if( !this.suppressNoChoice ){
 			// No Choice
@@ -445,6 +458,8 @@ var MultiFilterSelectionWidget = $n2.Class('MultiFilterSelectionWidget',{
 	
 	allChoicesLabel: null,
 
+	toolTip: null,
+
 	/* 
 	 * These are versions of functions that are throttled. These
 	 * functions touch the DOM structure and should not be called too.
@@ -459,6 +474,7 @@ var MultiFilterSelectionWidget = $n2.Class('MultiFilterSelectionWidget',{
 			,showService: null
 			,sourceModelId: null
 			,allChoicesLabel: null
+			,toolTip: null
 		},opts_);
 		
 		var _this = this;
@@ -467,6 +483,12 @@ var MultiFilterSelectionWidget = $n2.Class('MultiFilterSelectionWidget',{
 		this.showService = opts.showService;
 		this.sourceModelId = opts.sourceModelId;
 		this.allChoicesLabel = opts.allChoicesLabel;
+
+		if (opts.toolTip
+			&& typeof opts.toolTip === 'string'
+			&& opts.toolTip.length) {
+			this.toolTip = opts.toolTip;
+		}
 		
 		this.availableChoices = [];
 		this.selectedChoices = [];
@@ -550,11 +572,16 @@ var MultiFilterSelectionWidget = $n2.Class('MultiFilterSelectionWidget',{
 		
 		this.elemId = $n2.getUniqueId();
 		
-		$('<div>')
+		var $selector = $('<div>')
 			.attr('id',this.elemId)
 			.addClass('n2widget_multiFilterSelection')
 			.appendTo($container);
 		
+
+		if (this.toolTip) {
+			$selector.attr('title', this.toolTip);
+		}
+
 		this._throttledAvailableChoicesUpdated();
 		
 		$n2.log(this._classname, this);
@@ -758,7 +785,9 @@ var MultiFilterSelectionDropDownWidget = $n2.Class('MultiFilterSelectionDropDown
 	label: null,
 
 	showAsLink: null,
-	
+
+	toolTip: null,
+
 	/* 
 	 * These are versions of functions that are throttled. These
 	 * functions touch the DOM structure and should not be called too
@@ -776,6 +805,7 @@ var MultiFilterSelectionDropDownWidget = $n2.Class('MultiFilterSelectionDropDown
 			,noChoiceLabel: null
 			,label: null
 			,showAsLink: false
+			,toolTip: null
 		},opts_);
 		
 		var _this = this;
@@ -787,7 +817,13 @@ var MultiFilterSelectionDropDownWidget = $n2.Class('MultiFilterSelectionDropDown
 		this.noChoiceLabel = opts.noChoiceLabel;
 		this.label = opts.label;
 		this.showAsLink = opts.showAsLink;
-		
+
+		if (opts.toolTip
+			&& typeof opts.toolTip === 'string'
+			&& opts.toolTip.length) {
+			this.toolTip = opts.toolTip;
+		}
+
 		this.availableChoices = [];
 		this.selectedChoices = [];
 		this.selectedChoiceIdMap = {};
@@ -874,6 +910,10 @@ var MultiFilterSelectionDropDownWidget = $n2.Class('MultiFilterSelectionDropDown
 			.attr('id',this.elemId)
 			.addClass('n2widget_multiDropDownFilterSelection n2widget_multiDropDownFilterSelection_selection_hidden')
 			.appendTo($container);
+
+		if (this.toolTip) {
+			$elem.attr('title', this.toolTip);
+		}
 		
 		if( this.showAsLink ){
 			$elem.addClass('n2widget_multiDropDownFilterSelection_asLink');


### PR DESCRIPTION
Extended selection filter widgets to include a tooltip option.

Atlas builders can now include an `tooltip` option in their module widgets.json file with a string of text that will appear when a user hover's their cursor over a selection filter.

This functionality has been added to the single filter selection widget, multi filter selection widget, and the multi filter selection drop down widget.

widgets.json usage example:
```json
[
    {
        "widgetType": "singleFilterSelectionWidget"
        ,"containerClass": "nunaliit_module_title"
        ,"sourceModelId": "my_model_id"
        ,"allChoicesLabel": "All features"
	,"tooltip": "Select a feature from the filter list"
    }
]
```

fix #846 