### PR TITLE
Adding nunaliitOpenJdk11.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ Pre-compiled and packaged Nunaliit .tar.gz files can be found in the [Releases](
 
 The [Documentation](https://github.com/GCRC/nunaliit/wiki/)
 describes the setup and use of Nunaliit, as well as build instructions for developers.
+
+## this is the comments about installing and running a Nunaliit System on  openjdk11 #819 (Java > 8 compatibility)
+

--- a/nunaliitOpenJdk11.txt
+++ b/nunaliitOpenJdk11.txt
@@ -1,0 +1,2 @@
+Nunaliit system can be built and run under the environment of Ubuntu 18.04 server version, openjdk-11-jdk and virtualBox 6.0 without error.
+


### PR DESCRIPTION
There is a need to use Openjdk-11-jdk to run a nunaliit system and I succeeded in running the system without any error.
