### PR TITLE
adding the nunaliitOpenJdk11.txt file about the Nunaliit System on OpenJdk11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,9 @@ The [Documentation](https://github.com/GCRC/nunaliit/wiki/)
 describes the setup and use of Nunaliit, as well as build instructions for developers.
 
 ## this is the comments about installing and running a Nunaliit System on  openjdk11 #819 (Java > 8 compatibility)
-
+I built and run the Nunaliit system on the OpenJdk11.
+How to install "Openjdk-11-jdk" is 
+1)apt-cache pkgnames | grep jdk
+2)sudo apt-get install openjdk-11-jdk
+3)insert sudo password.
+after installing the "Openjdk-11-jdk" just insert the command "java -version" then you will see the java version the Ubuntu server shows.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ Pre-compiled and packaged Nunaliit .tar.gz files can be found in the [Releases](
 
 The [Documentation](https://github.com/GCRC/nunaliit/wiki/)
 describes the setup and use of Nunaliit, as well as build instructions for developers.
+
+## this is the comments about installing and running a Nunaliit System on  openjdk11 #819 (Java > 8 compatibility)
+

--- a/nunaliitOpenJdk11.txt
+++ b/nunaliitOpenJdk11.txt
@@ -1,0 +1,2 @@
+Nunaliit system can be built and run under the environment of Ubuntu 18.04 server version, openjdk-11-jdk and virtualBox 6.0 without error.
+

--- a/nunaliitOpenJdk11.txt
+++ b/nunaliitOpenJdk11.txt
@@ -1,2 +1,7 @@
 Nunaliit system can be built and run under the environment of Ubuntu 18.04 server version, openjdk-11-jdk and virtualBox 6.0 without error.
+How to download <openOpenjdk-11-jdk> at Ubuntu.
+1)apt-cache pkgnames | grep jdk
+2)sudo apt-get install openjdk-11-jdk
+3)insert sudo password.
+after installing the "Openjdk-11-jdk" just insert the command "java -version" then you will see the java version the Ubuntu server shows.
 


### PR DESCRIPTION
Nunaliit system can be built and run on OpenJdk11 without any problem.