### PR TITLE
User authentication for doc editing and creation on public layer.

### DIFF
--- a/nunaliit2-couch-submission/src/main/java/ca/carleton/gcrc/couch/submission/impl/SubmissionRobotThread.java
+++ b/nunaliit2-couch-submission/src/main/java/ca/carleton/gcrc/couch/submission/impl/SubmissionRobotThread.java
@@ -255,7 +255,9 @@ public class SubmissionRobotThread extends Thread implements CouchDbChangeListen
 		String docOwner = null;
 		if( null != submittedDoc ){
 			JSONObject nunaliitCreated = submittedDoc.optJSONObject("nunaliit_created");
-			docOwner = nunaliitCreated.getString("name");
+			if (null != nunaliitCreated) {
+				docOwner = nunaliitCreated.getString("name");
+			}
 		}
 		JSONArray nunaliitLayers = null;
 		if( null != submittedDoc ){
@@ -524,7 +526,7 @@ public class SubmissionRobotThread extends Thread implements CouchDbChangeListen
 	}
 	private boolean isDocOwner(String submitterName, String docOwner) {
 		boolean isOwner = false;
-		if ( null != submitterName ) {
+		if ( null != submitterName && null != docOwner) {
 			isOwner = submitterName.equals(docOwner);
 		}
 		return isOwner;


### PR DESCRIPTION
Now if a doc is on the public layer or layers start with "public_", anybody can create this doc without going through submission db, but people without admin privilege can only edit docs created by themselves. Editing other peoples document will still going through the submission_db flow.
I realize there may be some security concern, therefore, this pull request is just an experiment and we will discuss this issue with DEV team, before merging and solving this issue.
