### PR TITLE
Fixed incorrect export server url causing broken export tool

### DIFF
--- a/nunaliit2-couch-application/src/main/atlas_couchapp/_attachments/tools/js/export.js
+++ b/nunaliit2-couch-application/src/main/atlas_couchapp/_attachments/tools/js/export.js
@@ -61,7 +61,7 @@ function showDocs(opts_){
 				$('.exportResult').append($textarea);
 				$textarea.text(csv);
 			}
-			,onError: function(errStr) {
+			,onError: function(errStr, error) {
 				$('.exportResult').empty();
 				if( error ){
 					reportError(error);

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchExport.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchExport.js
@@ -816,7 +816,7 @@ var ExportService = $n2.Class('ExportService',{
 			,onError: $n2.reportError
 		},opts_);
 		
-		var url = this.serverUrl + 'export/definition/';
+		var url = this.serverUrl + 'definition/';
 		if( opts.fileName ){
 			url = url + opts.fileName;
 		} else {
@@ -931,7 +931,7 @@ var ExportService = $n2.Class('ExportService',{
 			,onError: $n2.reportError
 		},opts_);
 		
-		var url = this.serverUrl + 'export/definition/export';
+		var url = this.serverUrl + 'definition/export';
 
 		var data = {};
 		if( opts.docIds ){


### PR DESCRIPTION
incorrect url = https://gcrc.carleton.ca/servlet/export/export/definition/ (contains an incorrect 'export' duplicate in url)
correct url = https://gcrc.carleton.ca/servlet/export/definition/

fix #778 