### PR TITLE
Fixed bug with hanging loading screen when a couchDbView model is used.

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchDbPerspective.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchDbPerspective.js
@@ -821,7 +821,7 @@ var ModelCouchDbView = $n2.Class({
 						};
 					});
 
-					--this.loadingCount;
+					--_this.loadingCount;
 
 					_this._docInfoMapLoaded(docInfoByDocId);
 				}


### PR DESCRIPTION
Bug was caused by an out of scope variable being de-incremented.

fix #880