### PR TITLE
Issue 883 - added docs not being included in model state update

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchDbPerspective.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchDbPerspective.js
@@ -855,14 +855,16 @@ var ModelCouchDbView = $n2.Class({
 		for(docId in this.docsById){
 			oldDoc = null;
 			newDoc = null;
-			if( this.docsById[docId] ){
+
+			if( Object.hasOwnProperty.call(this.docsById, docId) ){
 				oldDoc = this.docsById[docId].clone;
 			};
-			if( docInfoMap[docId] ){
+
+			if( Object.hasOwnProperty.call(docInfoMap, docId) ){
 				newDoc = docInfoMap[docId].clone;
 			};
 
-			if( newDoc && oldDoc ){
+			if( oldDoc && newDoc ){
 				// This document persists. Check if revision changed
 				if( newDoc._rev === oldDoc._rev ){
 					// Nothing changed
@@ -871,30 +873,27 @@ var ModelCouchDbView = $n2.Class({
 					updated.push(newDoc);
 				};
 				
-			} else {
-				if( oldDoc ){
-					// This is a removed document
-					removed.push(oldDoc);
-				};
+			} else if( oldDoc ){
+				// This is a removed document
+				removed.push(oldDoc);
 			};
 		};
 		
-		// Detect added documents
+		// Detect added documents and adds initial view results.
 		for(docId in docInfoMap){
 			oldDoc = null;
 			newDoc = null;
-			if( this.docsById[docId] ){
+			if( Object.hasOwnProperty.call(this.docsById, docId) ){
 				oldDoc = this.docsById[docId].clone;
 			};
-			if( docInfoMap[docId] ){
+
+			if( Object.hasOwnProperty.call(docInfoMap, docId) ){
 				newDoc = docInfoMap[docId].clone;
 			};
 
-			if( !oldDoc ){
-				if( newDoc ){
-					// This was added
-					added.push(newDoc);
-				};
+			if( !oldDoc && newDoc ){
+				// This was added
+				added.push(newDoc);
 			};
 		};
 		

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchDbPerspective.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchDbPerspective.js
@@ -846,22 +846,23 @@ var ModelCouchDbView = $n2.Class({
 	},
 
 	_docInfoMapLoaded: function(docInfoMap){
+		var oldDoc, newDoc, docId;
 		var added = [];
 		var updated = [];
 		var removed = [];
 		
 		// Detect updated and removed documents
-		for(var docId in this.docsById){
-			var oldDoc;
+		for(docId in this.docsById){
+			oldDoc = null;
+			newDoc = null;
 			if( this.docsById[docId] ){
 				oldDoc = this.docsById[docId].clone;
 			};
-			var newDoc;
 			if( docInfoMap[docId] ){
 				newDoc = docInfoMap[docId].clone;
 			};
 
-			if( newDoc ){
+			if( newDoc && oldDoc ){
 				// This document persists. Check if revision changed
 				if( newDoc._rev === oldDoc._rev ){
 					// Nothing changed
@@ -871,25 +872,29 @@ var ModelCouchDbView = $n2.Class({
 				};
 				
 			} else {
-				// This is a removed document
-				removed.push(oldDoc);
+				if( oldDoc ){
+					// This is a removed document
+					removed.push(oldDoc);
+				};
 			};
 		};
 		
 		// Detect added documents
-		for(var docId in docInfoMap){
-			var oldDoc;
+		for(docId in docInfoMap){
+			oldDoc = null;
+			newDoc = null;
 			if( this.docsById[docId] ){
 				oldDoc = this.docsById[docId].clone;
 			};
-			var newDoc;
 			if( docInfoMap[docId] ){
 				newDoc = docInfoMap[docId].clone;
 			};
 
 			if( !oldDoc ){
-				// This was added
-				added.push(newDoc);
+				if( newDoc ){
+					// This was added
+					added.push(newDoc);
+				};
 			};
 		};
 		


### PR DESCRIPTION
Fixed issue with variable values from previous loop iterations persisting and causing new documents from being added when the model state is updated.

This bug was preventing models with the type couchDbView from correctly updating when new docs are added to a model (and consequently also the map). 

Fix #883 