### PR TITLE
Change geoname service url to https://secure.geonames.org

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.GeoNames.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.GeoNames.js
@@ -160,7 +160,7 @@ var GeoNameService = $n2.Class({
 	
 	initialize: function(opts_){
 		this.options = $n2.extend({
-			geoNamesUrl: 'http://api.geonames.org/'
+			geoNamesUrl: 'https://secure.geonames.org/'
 			,username: 'nunaliit'
 		},opts_);
 	},


### PR DESCRIPTION
Fix #888 
Changing the GeoNames service url to https version
https://secure.geonames.org