### PR TITLE
Sitemap proxy handling

### DIFF
--- a/nunaliit2-adhocQueries/pom.xml
+++ b/nunaliit2-adhocQueries/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-adhocQueries</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-adhocQueries</name>
@@ -14,7 +13,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-auth-common/pom.xml
+++ b/nunaliit2-auth-common/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-auth-common</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-auth-common</name>
@@ -13,7 +12,7 @@
   <dependencies>  
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-auth-cookie/pom.xml
+++ b/nunaliit2-auth-cookie/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-auth-cookie</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-auth-cookie</name>
@@ -14,7 +13,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-auth-http/pom.xml
+++ b/nunaliit2-auth-http/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-auth-http</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-auth-http</name>
@@ -14,7 +13,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-couch-command/pom.xml
+++ b/nunaliit2-couch-command/pom.xml
@@ -236,5 +236,11 @@
             <artifactId>jsoup</artifactId>
             <version>${jsoup.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.2.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/CommandRun.java
+++ b/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/CommandRun.java
@@ -1,39 +1,37 @@
 package ca.carleton.gcrc.couch.command;
 
-import java.io.File;
-import java.io.PrintStream;
-import java.net.URL;
-import java.util.EnumSet;
-
-import javax.servlet.DispatcherType;
-
-import ca.carleton.gcrc.couch.metadata.IndexServlet;
-import ca.carleton.gcrc.couch.metadata.RobotsServlet;
-import ca.carleton.gcrc.couch.metadata.SitemapServlet;
-import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
-import org.apache.log4j.rolling.RollingFileAppender;
-import org.apache.log4j.rolling.TimeBasedRollingPolicy;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.servlet.DefaultServlet;
-import org.eclipse.jetty.servlet.FilterHolder;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.servlets.GzipFilter;
-import org.eclipse.jetty.proxy.ProxyServlet;
-
 import ca.carleton.gcrc.couch.command.impl.CommandSupport;
 import ca.carleton.gcrc.couch.command.impl.TransparentProxyFixedEscaped;
 import ca.carleton.gcrc.couch.command.impl.TransparentWithRedirectServlet;
 import ca.carleton.gcrc.couch.command.servlet.ConfigServlet;
 import ca.carleton.gcrc.couch.date.DateServlet;
 import ca.carleton.gcrc.couch.export.ExportServlet;
+import ca.carleton.gcrc.couch.metadata.IndexServlet;
+import ca.carleton.gcrc.couch.metadata.RobotsServlet;
+import ca.carleton.gcrc.couch.metadata.SitemapServlet;
 import ca.carleton.gcrc.couch.simplifiedGeometry.SimplifiedGeometryServlet;
 import ca.carleton.gcrc.couch.submission.SubmissionServlet;
 import ca.carleton.gcrc.couch.user.UserServlet;
 import ca.carleton.gcrc.mail.MailServlet;
 import ca.carleton.gcrc.progress.ProgressServlet;
 import ca.carleton.gcrc.upload.UploadServlet;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.rolling.RollingFileAppender;
+import org.apache.log4j.rolling.TimeBasedRollingPolicy;
+import org.eclipse.jetty.proxy.ProxyServlet;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.servlet.FilterHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.servlets.GzipFilter;
+
+import javax.servlet.DispatcherType;
+import java.io.File;
+import java.io.PrintStream;
+import java.net.URL;
+import java.util.EnumSet;
 
 public class CommandRun implements Command {
 
@@ -93,7 +91,7 @@ public class CommandRun implements Command {
 		if( options.getArguments().size() > 1 ){
 			throw new Exception("Unexpected argument: "+options.getArguments().get(1));
 		}
-		
+
 		File atlasDir = gs.getAtlasDir();
 
 		// Load properties for atlas
@@ -254,6 +252,21 @@ public class CommandRun implements Command {
         	context.addServlet(servletHolder,"/servlet/mail/*");
         }
 
+		// index.html servlet
+		ServletHolder indexServlet = new ServletHolder(new IndexServlet());
+		indexServlet.setInitOrder(2);
+		context.addServlet(indexServlet, "/index.html");
+
+		// Servlet for serving sitemap.xml
+		ServletHolder sitemapServlet = new ServletHolder(new SitemapServlet());
+		sitemapServlet.setInitOrder(2);
+		context.addServlet(sitemapServlet, "/sitemap.xml");
+
+		// robots.txt servlet
+		ServletHolder robotsServlet = new ServletHolder(new RobotsServlet());
+		robotsServlet.setInitOrder(2);
+		context.addServlet(robotsServlet, "/robots.txt");
+
         // Proxy to site
         {
         	ServletHolder servletHolder = new ServletHolder(new TransparentWithRedirectServlet());
@@ -261,21 +274,6 @@ public class CommandRun implements Command {
         	servletHolder.setInitParameter("prefix", "/");
         	context.addServlet(servletHolder,"/*");
         }
-
-        // index.html servlet
-        ServletHolder indexServlet = new ServletHolder(new IndexServlet());
-        indexServlet.setInitOrder(2);
-        context.addServlet(indexServlet, "/index.html");
-
-        // Servlet for serving sitemap.xml
-        ServletHolder sitemapServlet = new ServletHolder(new SitemapServlet());
-        sitemapServlet.setInitOrder(2);
-        context.addServlet(sitemapServlet, "/sitemap.xml");
-
-        // robots.txt servlet
-        ServletHolder robotsServlet = new ServletHolder(new RobotsServlet());
-        robotsServlet.setInitOrder(2);
-        context.addServlet(robotsServlet, "/robots.txt");
 
 		// Start server
 		server.start();

--- a/nunaliit2-couch-command/src/test/java/ca/carleton/gcrc/couch/utils/CouchNunaliitUtilsTest.java
+++ b/nunaliit2-couch-command/src/test/java/ca/carleton/gcrc/couch/utils/CouchNunaliitUtilsTest.java
@@ -1,0 +1,30 @@
+package ca.carleton.gcrc.couch.utils;
+
+import junit.framework.TestCase;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CouchNunaliitUtilsTest extends TestCase {
+
+    //TODO: more testing req'd
+    public void testBuildBaseUrlNoProxy() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerName()).thenReturn("develop.gcrc.carleton.ca");
+        when(request.getServerPort()).thenReturn(80);
+        when(request.getHeader("REQUEST-SCHEME")).thenReturn("http");
+        when(request.getHeader("REQUEST-URI")).thenReturn("/atlases/atlas1/index.html");
+        when(request.getHeader("X-Forwarded-Host")).thenReturn(null);
+
+    }
+
+    public void testGetFolderPath() {
+        String url = "https://develop.gcrc.carleton.ca/sarah/sitemap.xml";
+        String path = CouchNunaliitUtils.getFolderPath(url);
+
+        assertEquals("sarah", path);
+    }
+}

--- a/nunaliit2-couch-command/src/test/java/ca/carleton/gcrc/couch/utils/CouchNunaliitUtilsTest.java
+++ b/nunaliit2-couch-command/src/test/java/ca/carleton/gcrc/couch/utils/CouchNunaliitUtilsTest.java
@@ -1,6 +1,7 @@
 package ca.carleton.gcrc.couch.utils;
 
 import junit.framework.TestCase;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -9,27 +10,149 @@ import static org.mockito.Mockito.when;
 
 public class CouchNunaliitUtilsTest extends TestCase {
 
-    //TODO: more testing req'd
-    public void testBuildBaseUrlNoProxy() {
+    public void testBuildBaseUrlNoProxyNonStandardPort() {
         HttpServletRequest request = mock(HttpServletRequest.class);
-        // These values should not be used while behind a proxy.
+        // These values should be used while not behind a proxy.
         when(request.getScheme()).thenReturn("http");
         when(request.getServerName()).thenReturn("develop.gcrc.carleton.ca");
         when(request.getServerPort()).thenReturn(8080);
-        // These are the headers we should be using.
+
+        // These are the headers we should be using only if proxied.
         when(request.getHeader(RequestHeaderConstants.REQUEST_SCHEME)).thenReturn("http");
         when(request.getHeader(RequestHeaderConstants.REQUEST_URI)).thenReturn("/atlases/atlas1/index.html");
         when(request.getHeader(RequestHeaderConstants.X_FORWARDED_HOST)).thenReturn(null);
         when(request.getHeader(RequestHeaderConstants.SERVER_PORT)).thenReturn("80");
 
+        String url = CouchNunaliitUtils.buildBaseUrl(request);
+        assertEquals("http://develop.gcrc.carleton.ca:8080/atlases/atlas1/", url);
+    }
+
+    public void testBuildBaseUrlNoProxyStandardPort() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        // These values should be used while not behind a proxy.
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerName()).thenReturn("develop.gcrc.carleton.ca");
+        when(request.getServerPort()).thenReturn(80);
+
+        // These are the headers we should be using only if proxied.
+        when(request.getHeader(RequestHeaderConstants.REQUEST_SCHEME)).thenReturn("http");
+        when(request.getHeader(RequestHeaderConstants.REQUEST_URI)).thenReturn("/atlases/atlas1/index.html");
+        when(request.getHeader(RequestHeaderConstants.X_FORWARDED_HOST)).thenReturn(null);
+        when(request.getHeader(RequestHeaderConstants.SERVER_PORT)).thenReturn("8080");
+
+        String url = CouchNunaliitUtils.buildBaseUrl(request);
+        assertEquals("http://develop.gcrc.carleton.ca/atlases/atlas1/", url);
+    }
+
+    public void testBuildBaseUrlNoProxySslStandardPort() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        // These values should be used while not behind a proxy.
+        when(request.getScheme()).thenReturn("https");
+        when(request.getServerName()).thenReturn("develop.gcrc.carleton.ca");
+        when(request.getServerPort()).thenReturn(443);
+
+        // These are the headers we should be using only if proxied.
+        when(request.getHeader(RequestHeaderConstants.REQUEST_SCHEME)).thenReturn("http");
+        when(request.getHeader(RequestHeaderConstants.REQUEST_URI)).thenReturn("/atlases/atlas1/index.html");
+        when(request.getHeader(RequestHeaderConstants.X_FORWARDED_HOST)).thenReturn(null);
+        when(request.getHeader(RequestHeaderConstants.SERVER_PORT)).thenReturn("8080");
+
+        String url = CouchNunaliitUtils.buildBaseUrl(request);
+        assertEquals("https://develop.gcrc.carleton.ca/atlases/atlas1/", url);
+    }
 
 
+    public void testBuildBaseUrlProxiedNonStandardPort() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        // These values should be used while not behind a proxy.
+        when(request.getScheme()).thenReturn("https");
+        when(request.getServerName()).thenReturn("noproxy.gcrc.carleton.ca");
+        when(request.getServerPort()).thenReturn(80);
+
+        // These are the headers we should be using only if proxied.
+        when(request.getHeader(RequestHeaderConstants.REQUEST_SCHEME)).thenReturn("http");
+        when(request.getHeader(RequestHeaderConstants.REQUEST_URI)).thenReturn("/atlases/atlas1/index.html");
+        when(request.getHeader(RequestHeaderConstants.X_FORWARDED_HOST)).thenReturn("develop.gcrc.carleton.ca");
+        when(request.getHeader(RequestHeaderConstants.SERVER_PORT)).thenReturn("8080");
+
+        String url = CouchNunaliitUtils.buildBaseUrl(request);
+        assertEquals("http://develop.gcrc.carleton.ca:8080/atlases/atlas1/", url);
+    }
+
+    public void testBuildBaseUrlProxiedStandardPort() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        // These values should be used while not behind a proxy.
+        when(request.getScheme()).thenReturn("https");
+        when(request.getServerName()).thenReturn("noproxy.gcrc.carleton.ca");
+        when(request.getServerPort()).thenReturn(8080);
+
+        // These are the headers we should be using only if proxied.
+        when(request.getHeader(RequestHeaderConstants.REQUEST_SCHEME)).thenReturn("http");
+        when(request.getHeader(RequestHeaderConstants.REQUEST_URI)).thenReturn("/atlases/atlas1/index.html");
+        when(request.getHeader(RequestHeaderConstants.X_FORWARDED_HOST)).thenReturn("develop.gcrc.carleton.ca");
+        when(request.getHeader(RequestHeaderConstants.SERVER_PORT)).thenReturn("80");
+
+        String url = CouchNunaliitUtils.buildBaseUrl(request);
+        assertEquals("http://develop.gcrc.carleton.ca/atlases/atlas1/", url);
+    }
+
+    public void testBuildBaseUrlProxiedSslStandardPort() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        // These values should be used while not behind a proxy.
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerName()).thenReturn("noproxy.gcrc.carleton.ca");
+        when(request.getServerPort()).thenReturn(8443);
+
+        // These are the headers we should be using only if proxied.
+        when(request.getHeader(RequestHeaderConstants.REQUEST_SCHEME)).thenReturn("https");
+        when(request.getHeader(RequestHeaderConstants.REQUEST_URI)).thenReturn("/atlases/atlas1/index.html");
+        when(request.getHeader(RequestHeaderConstants.X_FORWARDED_HOST)).thenReturn("develop.gcrc.carleton.ca");
+        when(request.getHeader(RequestHeaderConstants.SERVER_PORT)).thenReturn("443");
+
+        String url = CouchNunaliitUtils.buildBaseUrl(request);
+        assertEquals("https://develop.gcrc.carleton.ca/atlases/atlas1/", url);
+    }
+
+    public void testBuildBaseUrlNoRequestUri() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        // These values should be used while not behind a proxy.
+        when(request.getScheme()).thenReturn("http");
+        when(request.getServerName()).thenReturn("noproxy.gcrc.carleton.ca");
+        when(request.getServerPort()).thenReturn(8443);
+
+        // These are the headers we should be using only if proxied.
+        when(request.getHeader(RequestHeaderConstants.REQUEST_SCHEME)).thenReturn("https");
+        when(request.getHeader(RequestHeaderConstants.REQUEST_URI)).thenReturn(null);
+        when(request.getHeader(RequestHeaderConstants.X_FORWARDED_HOST)).thenReturn("develop.gcrc.carleton.ca");
+        when(request.getHeader(RequestHeaderConstants.SERVER_PORT)).thenReturn("443");
+
+        String url = CouchNunaliitUtils.buildBaseUrl(request);
+        assertEquals("https://develop.gcrc.carleton.ca/", url);
     }
 
     public void testGetFolderPath() {
-        String url = "https://develop.gcrc.carleton.ca/sarah/sitemap.xml";
+        String url = "https://develop.gcrc.carleton.ca/atlas/index.html";
         String path = CouchNunaliitUtils.getFolderPath(url);
+        assertEquals("atlas", path);
 
-        assertEquals("sarah", path);
+        url = "https://develop.gcrc.carleton.ca/atlases/atlas1/index.html?module=module.map";
+        path = CouchNunaliitUtils.getFolderPath(url);
+        assertEquals("atlases/atlas1", path);
+
+        url = "https://develop.gcrc.carleton.ca/atlases/atlas1/";
+        path = CouchNunaliitUtils.getFolderPath(url);
+        assertEquals("atlases/atlas1", path);
+
+        url = "https://develop.gcrc.carleton.ca/index.html";
+        path = CouchNunaliitUtils.getFolderPath(url);
+        assertTrue(StringUtils.isBlank(path));
+
+        url = "https://develop.gcrc.carleton.ca";
+        path = CouchNunaliitUtils.getFolderPath(url);
+        assertTrue(StringUtils.isBlank(path));
+
+        url = "https://develop.gcrc.carleton.ca/";
+        path = CouchNunaliitUtils.getFolderPath(url);
+        assertTrue(StringUtils.isBlank(path));
     }
 }

--- a/nunaliit2-couch-command/src/test/java/ca/carleton/gcrc/couch/utils/CouchNunaliitUtilsTest.java
+++ b/nunaliit2-couch-command/src/test/java/ca/carleton/gcrc/couch/utils/CouchNunaliitUtilsTest.java
@@ -12,12 +12,17 @@ public class CouchNunaliitUtilsTest extends TestCase {
     //TODO: more testing req'd
     public void testBuildBaseUrlNoProxy() {
         HttpServletRequest request = mock(HttpServletRequest.class);
+        // These values should not be used while behind a proxy.
         when(request.getScheme()).thenReturn("http");
         when(request.getServerName()).thenReturn("develop.gcrc.carleton.ca");
-        when(request.getServerPort()).thenReturn(80);
-        when(request.getHeader("REQUEST-SCHEME")).thenReturn("http");
-        when(request.getHeader("REQUEST-URI")).thenReturn("/atlases/atlas1/index.html");
-        when(request.getHeader("X-Forwarded-Host")).thenReturn(null);
+        when(request.getServerPort()).thenReturn(8080);
+        // These are the headers we should be using.
+        when(request.getHeader(RequestHeaderConstants.REQUEST_SCHEME)).thenReturn("http");
+        when(request.getHeader(RequestHeaderConstants.REQUEST_URI)).thenReturn("/atlases/atlas1/index.html");
+        when(request.getHeader(RequestHeaderConstants.X_FORWARDED_HOST)).thenReturn(null);
+        when(request.getHeader(RequestHeaderConstants.SERVER_PORT)).thenReturn("80");
+
+
 
     }
 

--- a/nunaliit2-couch-date/pom.xml
+++ b/nunaliit2-couch-date/pom.xml
@@ -10,7 +10,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-couch-export/pom.xml
+++ b/nunaliit2-couch-export/pom.xml
@@ -10,7 +10,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-couch-metadata/pom.xml
+++ b/nunaliit2-couch-metadata/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <version>${servlet-api.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/nunaliit2-couch-metadata/src/main/java/ca/carleton/gcrc/couch/metadata/IndexServlet.java
+++ b/nunaliit2-couch-metadata/src/main/java/ca/carleton/gcrc/couch/metadata/IndexServlet.java
@@ -4,6 +4,8 @@ import ca.carleton.gcrc.couch.client.CouchDb;
 import ca.carleton.gcrc.couch.client.impl.listener.HtmlAttachmentChangeListener;
 import ca.carleton.gcrc.couch.client.impl.listener.ModuleMetadataChangeListener;
 import ca.carleton.gcrc.couch.utils.CouchNunaliitConstants;
+import ca.carleton.gcrc.couch.utils.CouchNunaliitUtils;
+import ca.carleton.gcrc.couch.utils.RequestHeaderConstants;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.jsoup.nodes.Document;
@@ -108,9 +110,14 @@ public class IndexServlet extends HttpServlet
      */
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+        CouchNunaliitUtils.logRequestData(request);
         JSONObject metadata = null;
 
         String queryString = request.getQueryString();
+        // Check for custom header in case we are behind a proxy.
+        if (StringUtils.isNotBlank(request.getHeader(RequestHeaderConstants.QUERY_STRING))) {
+            queryString = request.getHeader(RequestHeaderConstants.QUERY_STRING);
+        }
 
         logger.trace("Received request with query string {}", queryString);
         if (StringUtils.isNotBlank(queryString)) {

--- a/nunaliit2-couch-metadata/src/main/java/ca/carleton/gcrc/couch/metadata/SitemapBuilderAtlasChangeListener.java
+++ b/nunaliit2-couch-metadata/src/main/java/ca/carleton/gcrc/couch/metadata/SitemapBuilderAtlasChangeListener.java
@@ -143,9 +143,9 @@ public final class SitemapBuilderAtlasChangeListener extends AbstractCouchDbChan
         // Now build final set of relative URLs.
         Set<String> tempRelativeUrls = new HashSet<>(links.get(HREF));
         // Add root path, in case it's not linked in navigation menu.
-        tempRelativeUrls.add("./index.html");
+        tempRelativeUrls.add("index.html");
         for (String module : links.get(MODULE)) {
-            tempRelativeUrls.add(String.format("./index.html?module=%s", module));
+            tempRelativeUrls.add(String.format("index.html?module=%s", module));
         }
 
         synchronized (lockObj) {
@@ -173,7 +173,15 @@ public final class SitemapBuilderAtlasChangeListener extends AbstractCouchDbChan
                     }
                     else if (next.has(HREF) && StringUtils.isNotBlank(next.optString(HREF))
                             && !next.optString(HREF).startsWith("http")) {
-                        links.get(HREF).add(next.getString(HREF));
+                        // Remove ./ or / at the beginning of the HREF.
+                        String href = next.getString(HREF);
+                        if (href.startsWith("./")) {
+                            href = href.substring(2);
+                        }
+                        else if (href.startsWith("/")) {
+                            href = href.substring(1);
+                        }
+                        links.get(HREF).add(href);
                     }
                     // Recurse if this item has sub-items.
                     if (next.has(ITEMS)) {

--- a/nunaliit2-couch-metadata/src/main/java/ca/carleton/gcrc/couch/metadata/SitemapServlet.java
+++ b/nunaliit2-couch-metadata/src/main/java/ca/carleton/gcrc/couch/metadata/SitemapServlet.java
@@ -56,6 +56,7 @@ public class SitemapServlet extends HttpServlet
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+        CouchNunaliitUtils.logRequestData(request);
         logger.debug("Sitemap request received");
         List<String> relativeUrls = sitemapBuilderAtlasChangeListener.getRelativeUrls();
         if (!relativeUrls.isEmpty()) {

--- a/nunaliit2-couch-metadata/src/test/java/ca/carleton/gcrc/couch/metadata/SitemapBuilderAtlasChangeListenerTest.java
+++ b/nunaliit2-couch-metadata/src/test/java/ca/carleton/gcrc/couch/metadata/SitemapBuilderAtlasChangeListenerTest.java
@@ -45,10 +45,10 @@ public class SitemapBuilderAtlasChangeListenerTest extends TestCase
 
         assertNotNull(relativeUrls);
         assertEquals(4, relativeUrls.size());
-        assertTrue(relativeUrls.contains("./index.html"));
-        assertTrue(relativeUrls.contains("./tools/index.html"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.test2_canvas"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.demo"));
+        assertTrue(relativeUrls.contains("index.html"));
+        assertTrue(relativeUrls.contains("tools/index.html"));
+        assertTrue(relativeUrls.contains("index.html?module=module.test2_canvas"));
+        assertTrue(relativeUrls.contains("index.html?module=module.demo"));
     }
 
     public void testTwoLevelNavigation() {
@@ -57,21 +57,21 @@ public class SitemapBuilderAtlasChangeListenerTest extends TestCase
 
         assertNotNull(relativeUrls);
         assertEquals(15, relativeUrls.size());
-        assertTrue(relativeUrls.contains("./index.html"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.seaice"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.conservation"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.aboutatlas"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.ncri.explore"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.boundaries"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.weatherstationdatavisualizer"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.placenames"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.oldsettlement"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.ocean.protecting"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.ncri.birds"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.ncri.fish"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.contactus"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.sleepyriver.ncri.marinemammals"));
+        assertTrue(relativeUrls.contains("index.html"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.seaice"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.conservation"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.aboutatlas"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.ncri.explore"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.boundaries"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.weatherstationdatavisualizer"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.placenames"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.oldsettlement"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.ocean.protecting"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.ncri.birds"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.ncri.fish"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.contactus"));
+        assertTrue(relativeUrls.contains("index.html?module=module.sleepyriver.ncri.marinemammals"));
     }
 
     public void testThreeLevelNavigation() {
@@ -80,11 +80,11 @@ public class SitemapBuilderAtlasChangeListenerTest extends TestCase
 
         assertNotNull(relativeUrls);
         assertEquals(5, relativeUrls.size());
-        assertTrue(relativeUrls.contains("./index.html"));
-        assertTrue(relativeUrls.contains("./tools/index.html"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.test5_map"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.test5_canvas"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.test5_anothermodule"));
+        assertTrue(relativeUrls.contains("index.html"));
+        assertTrue(relativeUrls.contains("tools/index.html"));
+        assertTrue(relativeUrls.contains("index.html?module=module.test5_map"));
+        assertTrue(relativeUrls.contains("index.html?module=module.test5_canvas"));
+        assertTrue(relativeUrls.contains("index.html?module=module.test5_anothermodule"));
     }
 
     public void testWithMetadataNavigation() {
@@ -93,10 +93,10 @@ public class SitemapBuilderAtlasChangeListenerTest extends TestCase
 
         assertNotNull(relativeUrls);
         assertEquals(5, relativeUrls.size());
-        assertTrue(relativeUrls.contains("./index.html"));
-        assertTrue(relativeUrls.contains("./tools/index.html"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.canvas"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.demo"));
-        assertTrue(relativeUrls.contains("./index.html?module=module.map"));
+        assertTrue(relativeUrls.contains("index.html"));
+        assertTrue(relativeUrls.contains("tools/index.html"));
+        assertTrue(relativeUrls.contains("index.html?module=module.canvas"));
+        assertTrue(relativeUrls.contains("index.html?module=module.demo"));
+        assertTrue(relativeUrls.contains("index.html?module=module.map"));
     }
 }

--- a/nunaliit2-couch-onUpload/pom.xml
+++ b/nunaliit2-couch-onUpload/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-couch-simplifiedGeometry/pom.xml
+++ b/nunaliit2-couch-simplifiedGeometry/pom.xml
@@ -22,7 +22,7 @@
   	</dependency>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-couch-submission/pom.xml
+++ b/nunaliit2-couch-submission/pom.xml
@@ -10,7 +10,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 			<version>${servlet-api.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/nunaliit2-couch-user/pom.xml
+++ b/nunaliit2-couch-user/pom.xml
@@ -42,7 +42,7 @@
   	</dependency>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-couch-utils/pom.xml
+++ b/nunaliit2-couch-utils/pom.xml
@@ -6,7 +6,6 @@
         <groupId>ca.carleton.gcrc</groupId>
         <version>2.2.9-SNAPSHOT</version>
     </parent>
-    <groupId>ca.carleton.gcrc</groupId>
     <artifactId>nunaliit2-couch-utils</artifactId>
     <name>nunaliit2-couch-utils</name>
     <version>2.2.9-SNAPSHOT</version>
@@ -32,7 +31,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <version>${servlet-api.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/nunaliit2-couch-utils/src/main/java/ca/carleton/gcrc/couch/utils/CouchNunaliitUtils.java
+++ b/nunaliit2-couch-utils/src/main/java/ca/carleton/gcrc/couch/utils/CouchNunaliitUtils.java
@@ -218,7 +218,8 @@ public class CouchNunaliitUtils {
 
 	/**
 	 * Get folder path for base URL. Could be http://www.domain.com or possibly http://www.domain.com/atlas1 or
-	 * http://www.domain.com/atlases/atlas1?module=module.map. Finds the 'atlases/atlas1' path.
+	 * http://www.domain.com/atlases/atlas1?module=module.map. Finds the 'atlases/atlas1' path. Also will properly
+	 * find path /atlas/ in "/atlas/index.html".  The REQUEST_URI custom header passes this in, omitting the domain.
 	 *
 	 * @param url The full URL to search.
 	 * @return The path between the first / to the query string. Returns null if no path found.

--- a/nunaliit2-couch-utils/src/main/java/ca/carleton/gcrc/couch/utils/RequestHeaderConstants.java
+++ b/nunaliit2-couch-utils/src/main/java/ca/carleton/gcrc/couch/utils/RequestHeaderConstants.java
@@ -1,8 +1,9 @@
 package ca.carleton.gcrc.couch.utils;
 
 /**
- * HTTP request header constants that aren't availble elsewhere. Also incluses headers setup on the Apache server manually. Should be used when an atlas is hosted behind a proxy, since the
- * servlet won't get the originating scheme, URI, query string or port in the request headers.
+ * HTTP request header constants that aren't available elsewhere. Also includes headers setup on the Apache server
+ * manually. Should be used when an atlas is hosted behind a proxy, since the servlet won't get the original scheme,
+ * URI, query string or port in the request headers.
  */
 public class RequestHeaderConstants {
     private RequestHeaderConstants() {
@@ -20,8 +21,8 @@ public class RequestHeaderConstants {
      * http or https
      */
     public static final String REQUEST_SCHEME = "REQUEST_SCHEME";
+    /** Originaal request port. */
     public static final String SERVER_PORT = "SERVER_PORT";
-
-    /** Standard header for proxies, represents originating host. */
+    /** Standard header for proxies, represents original request host. */
     public static final String X_FORWARDED_HOST = "X-Forwarded-Host";
 }

--- a/nunaliit2-couch-utils/src/main/java/ca/carleton/gcrc/couch/utils/RequestHeaderConstants.java
+++ b/nunaliit2-couch-utils/src/main/java/ca/carleton/gcrc/couch/utils/RequestHeaderConstants.java
@@ -1,0 +1,27 @@
+package ca.carleton.gcrc.couch.utils;
+
+/**
+ * HTTP request header constants that aren't availble elsewhere. Also incluses headers setup on the Apache server manually. Should be used when an atlas is hosted behind a proxy, since the
+ * servlet won't get the originating scheme, URI, query string or port in the request headers.
+ */
+public class RequestHeaderConstants {
+    private RequestHeaderConstants() {
+    }
+
+    /**
+     * e.g., module=module.mycoolmap
+     */
+    public static final String QUERY_STRING = "QUERY_STRING";
+    /**
+     * e.g., /atlas1/index.html
+     */
+    public static final String REQUEST_URI = "REQUEST_URI";
+    /**
+     * http or https
+     */
+    public static final String REQUEST_SCHEME = "REQUEST_SCHEME";
+    public static final String SERVER_PORT = "SERVER_PORT";
+
+    /** Standard header for proxies, represents originating host. */
+    public static final String X_FORWARDED_HOST = "X-Forwarded-Host";
+}

--- a/nunaliit2-dbSec/pom.xml
+++ b/nunaliit2-dbSec/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-dbSec</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-dbSec</name>
@@ -14,7 +13,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-dbWeb/pom.xml
+++ b/nunaliit2-dbWeb/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-dbWeb</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-dbWeb</name>
@@ -13,7 +12,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-jdbc-json/pom.xml
+++ b/nunaliit2-jdbc-json/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-jdbc-json</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-jdbc-json</name>
@@ -13,7 +12,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-jdbc/pom.xml
+++ b/nunaliit2-jdbc/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-jdbc</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-jdbc</name>
@@ -14,7 +13,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-json/pom.xml
+++ b/nunaliit2-json/pom.xml
@@ -17,7 +17,7 @@
   	</dependency>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-mail/pom.xml
+++ b/nunaliit2-mail/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-progress/pom.xml
+++ b/nunaliit2-progress/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-progress</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-progress</name>
@@ -13,7 +12,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-search/pom.xml
+++ b/nunaliit2-search/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-search</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-search</name>
@@ -13,7 +12,7 @@
   <dependencies>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-upload/pom.xml
+++ b/nunaliit2-upload/pom.xml
@@ -5,7 +5,6 @@
     <groupId>ca.carleton.gcrc</groupId>
     <version>2.2.9-SNAPSHOT</version>
   </parent>
-  <groupId>ca.carleton.gcrc</groupId>
   <artifactId>nunaliit2-upload</artifactId>
   <version>2.2.9-SNAPSHOT</version>
   <name>nunaliit2-upload</name>
@@ -23,7 +22,7 @@
   	</dependency>
   	<dependency>
   		<groupId>javax.servlet</groupId>
-  		<artifactId>servlet-api</artifactId>
+  		<artifactId>javax.servlet-api</artifactId>
   		<version>${servlet-api.version}</version>
   		<scope>provided</scope>
   	</dependency>

--- a/nunaliit2-utils/pom.xml
+++ b/nunaliit2-utils/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>ca.carleton.gcrc</groupId>
 		<version>2.2.9-SNAPSHOT</version>
 	</parent>
-	<groupId>ca.carleton.gcrc</groupId>
 	<artifactId>nunaliit2-utils</artifactId>
 	<name>nunaliit2-utils</name>
 	<version>2.2.9-SNAPSHOT</version>
@@ -62,7 +61,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
 			<version>${servlet-api.version}</version>
 			<scope>provided</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
 		<maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
 		<mustache.version>0.8.18</mustache.version>
-		<servlet-api.version>2.5</servlet-api.version>
+		<servlet-api.version>3.1.0</servlet-api.version>
 		<slf4j.version>1.7.13</slf4j.version>
 		<jsoup.version>1.12.1</jsoup.version>
 	</properties>


### PR DESCRIPTION
Fixes a few issues with generating sitemap:

- When behind a proxy, we weren't using the correct host, scheme and port (using the local server info instead).  This was resolved by adding custom headers to Apache, and getting these headers from the request object (REQUEST_URI, QUERY_STRING, REQUEST_SCHEME, SERVER_PORT).
- Cleanup the URLs published in the sitemap.xml to remove things like `/./` (superfluous dot and slash).
- I also updated our servlet-api version since we were significantly out of date. In fact using a version not aligned with Jetty 9.2's recommended servlet API version.