### PR TITLE
fix #900: Set the accessibility system property to false at startup, …

### DIFF
--- a/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/Main.java
+++ b/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/Main.java
@@ -44,6 +44,12 @@ public class Main {
 	}
 
 	static public void main(String[] args) {
+
+		// Resolves an issue when we try to scale an image, we get
+		// "java.awt.AWTError: Assistive Technology not found: org.GNOME.Accessibility.AtkWrapper"
+		// On headless JDK's, the AWT class is looking for this feature that is not available.
+		System.setProperty("javax.accessibility.assistive_technologies", "");
+
 		GlobalSettings globalSettings = null;
 		
 		try {


### PR DESCRIPTION
Set the accessibility system property to false at startup, so that installations with headless JDK do not attempt to use this. It appears to be an AWT bug.