### PR TITLE
Issue 820

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.widgetLegend.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.widgetLegend.js
@@ -162,6 +162,7 @@ POSSIBILITY OF SUCH DAMAGE.
 						for (var i in this.labels) {
 							if (_loc(effectiveLabel) === _loc(this.labels[i])) {
 								atLeastOne = true;
+								break;
 							}
 						}
 					}
@@ -735,6 +736,7 @@ POSSIBILITY OF SUCH DAMAGE.
 						for (var j in this.labels) {
 							if (_loc(effectiveLabel) === _loc(this.labels[j])) {
 								atLeastOne = true;
+								break;
 							}
 						}
 					}

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.widgetLegend.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.widgetLegend.js
@@ -152,14 +152,21 @@ POSSIBILITY OF SUCH DAMAGE.
 				if( style.label ){
 					var effectiveLabel = _loc( style.label );
 					var labelInfo = stylesByLabel[effectiveLabel];
-					if( !labelInfo ){
+					if (!labelInfo) {
 						labelInfo = {};
 						stylesByLabel[effectiveLabel] = labelInfo;
-					};
+					}
 					labelInfo[styleId] = styleInfo;
-					atLeastOne = true;
-				};
-			};
+
+					if (this.labels) {
+						for (var i in this.labels) {
+							if (_loc(effectiveLabel) === _loc(this.labels[i])) {
+								atLeastOne = true;
+							}
+						}
+					}
+				}
+			}
 
 			// If at least one style with label, then must display
 			if( atLeastOne ){
@@ -717,14 +724,21 @@ POSSIBILITY OF SUCH DAMAGE.
 				var atLeastOne = false;
 
 				for(var i=0,e=_this.completeChoices.length; i < e; i++){
-						var labelId = _this.completeChoices[i].labelId;
-						var effectiveLabel = _loc( _this.completeChoices[i].label );
-						stylesByLabel[labelId] = {
-								effectivelabel: effectiveLabel
-								,labelId : labelId
-						};
-						atLeastOne = true;
-				};
+					var labelId = _this.completeChoices[i].labelId;
+					var effectiveLabel = _loc( _this.completeChoices[i].label );
+					stylesByLabel[labelId] = {
+							effectivelabel: effectiveLabel
+							,labelId : labelId
+					};
+					
+					if (this.labels) {
+						for (var j in this.labels) {
+							if (_loc(effectiveLabel) === _loc(this.labels[j])) {
+								atLeastOne = true;
+							}
+						}
+					}
+				}
 
 				// If at least one style with label, then must display
 				if( atLeastOne ){


### PR DESCRIPTION
Added a check to ensure that at least one style labels exist in a supplied labels array, to prevent the empty legend from appearing if a labels array is being used.
 
fix #820 