### PR TITLE
fix #906: Add file size to the image/audio/video threshold settings i…

### DIFF
--- a/nunaliit2-couch-onUpload/src/main/java/ca/carleton/gcrc/couch/onUpload/pdf/PdfFileConverter.java
+++ b/nunaliit2-couch-onUpload/src/main/java/ca/carleton/gcrc/couch/onUpload/pdf/PdfFileConverter.java
@@ -164,8 +164,8 @@ public class PdfFileConverter implements FileConversionPlugin {
 			pdfbox.createPdfThumbnail(
 					pdfInfo, 
 					thumbnailFile, 
-					MultimediaConfiguration.IMAGE_THUMB_WIDTH, 
-					MultimediaConfiguration.IMAGE_THUMB_HEIGHT
+					MultimediaConfiguration.getImageThumbWidth(),
+					MultimediaConfiguration.getImageThumbHeight()
 				);
 
 			// Get information about thumbnail

--- a/nunaliit2-couch-sdk/src/main/templates/config/multimedia.properties
+++ b/nunaliit2-couch-sdk/src/main/templates/config/multimedia.properties
@@ -218,31 +218,43 @@
 # multimedia.conversion.audio.threshold
 #
 # Values, separated by commas, used as threshold to initiate conversion of external audio
-# files.
+# files. Multiple thresholds can be defined and separated by a pipe ('|'). For example:
+#    mp4,250000,10|aac,128000,10
+#
+# Each threshold is defined with these fields:
 # 0 : Acceptable codec (* for any)
 # 1 : Maximum audio bitrate (* for any)
+# 2 : Maximum file size in megabytes (MB), whole numbers only (* for any)
 #
-#multimedia.conversion.audio.threshold=mpeg,250000
+#multimedia.conversion.audio.threshold=aac,250000,10
 
 #
 # multimedia.conversion.video.threshold
 #
 # Values, separated by commas, used as threshold to initiate conversion of external video
-# files.
+# files.  Multiple thresholds can be defined and separated by a pipe ('|'). For example:
+#    h264,250000,aac,250000,*,1000|mp4,250000,aac,250000,*,1000
+#
+# Each threshold is defined with these fields:
 # 0 : Acceptable video codec (* for any)
 # 1 : Maximum video bitrate (* for any)
 # 2 : Acceptable audio codec (* for any)
 # 3 : Maximum audio bitrate (* for any)
 # 4 : Largest acceptable dimension, in pixels (* for any)
+# 5 : Maximum file size in megabytes (MB), whole numbers only (* for any)
 #
-#multimedia.conversion.video.threshold=h264,250000,mpeg4aac,250000,*
+#multimedia.conversion.video.threshold=h264,250000,aac,250000,*,1000
 
 #
 # multimedia.conversion.image.threshold
 #
 # Values, separated by commas, used as threshold to initiate conversion of external image
-# files.
+# files. Multiple thresholds can be defined and separated by a pipe ('|'). For example:
+#    JPEG,500,*|png,500,*|gif,500,*
+#
+# Each threshold is defined with these fields:
 # 0 : Acceptable image format (* for any)
 # 1 : Largest acceptable dimension, in pixels (* for any)
+# 2 : Maximum file size in megabytes (MB), whole numbers only (* for any)
 #
-#multimedia.conversion.image.threshold=JPEG,500
+#multimedia.conversion.image.threshold=JPEG,500,*

--- a/nunaliit2-multimedia/pom.xml
+++ b/nunaliit2-multimedia/pom.xml
@@ -51,5 +51,10 @@
 		<artifactId>pdfbox</artifactId>
 		<version>2.0.15</version>
 	</dependency>
+	<dependency>
+		<groupId>commons-io</groupId>
+		<artifactId>commons-io</artifactId>
+		<version>${commons-io.version}</version>
+	</dependency>
   </dependencies>
 </project>

--- a/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/MultimediaConversionRequest.java
+++ b/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/MultimediaConversionRequest.java
@@ -1,8 +1,10 @@
 package ca.carleton.gcrc.olkit.multimedia.converter;
 
 import java.io.File;
+import java.math.BigInteger;
 
 import ca.carleton.gcrc.olkit.multimedia.xmp.XmpInfo;
+import org.apache.commons.io.FileUtils;
 
 
 public class MultimediaConversionRequest {
@@ -12,6 +14,7 @@ public class MultimediaConversionRequest {
 	private boolean thumbnailCreated = false;
 	private boolean skipConversion = false;
 	private File inFile;
+	private long inFileSizeMb;
 	private int inHeight = 0;
 	private int inWidth = 0;
 	private float inDurationInSec = (float) 0.0;
@@ -31,6 +34,14 @@ public class MultimediaConversionRequest {
 	}
 	public void setInFile(File inFile) {
 		this.inFile = inFile;
+		BigInteger sizeInBytes = FileUtils.sizeOfAsBigInteger(inFile);
+		BigInteger sizeInMbBigInt = sizeInBytes.divide(BigInteger.valueOf(FileUtils.ONE_MB));
+		// Safe to convert to long now that it's in MB.
+		inFileSizeMb = sizeInMbBigInt.longValue();
+	}
+
+	public long getInFileSizeMb() {
+		return inFileSizeMb;
 	}
 
 	public int getInHeight() {

--- a/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/MultimediaConversionThreshold.java
+++ b/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/MultimediaConversionThreshold.java
@@ -1,14 +1,9 @@
 package ca.carleton.gcrc.olkit.multimedia.converter;
 
-public interface MultimediaConversionThreshold {
+public interface MultimediaConversionThreshold
+{
+	boolean isConversionRequired(String videoFormat, Long videoRate, String audioFormat, Long audioRate,
+								 Long imageWidth, Long imageHeight, Long fileSizeMb);
 
-	boolean isConversionRequired(
-		String videoFormat ,Long videoRate
-		,String audioFormat ,Long audioRate
-		,Long imageWidth ,Long imageHeight
-		);
-
-	boolean isResizeRequired(
-		Long imageWidth ,Long imageHeight
-		);
+	boolean isResizeRequired(Long imageWidth, Long imageHeight);
 }

--- a/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/DefaultThresholdAudio.java
+++ b/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/DefaultThresholdAudio.java
@@ -4,27 +4,22 @@ import ca.carleton.gcrc.olkit.multimedia.converter.MultimediaConversionThreshold
 
 public class DefaultThresholdAudio implements MultimediaConversionThreshold {
 
+	protected static final long DEFAULT_MAX_BITRATE = 250000;
+	protected static final String DEFAULT_REQUIRED_AUDIO_ENCODING = "aac";
+
 	@Override
-	public boolean isConversionRequired(
-			String videoFormat
-			,Long videoRate
-			,String audioFormat
-			,Long audioRate
-			,Long imageWidth
-			,Long imageHeight
-			) {
+	public boolean isConversionRequired(String videoFormat, Long videoRate, String audioFormat, Long audioRate,
+										Long imageWidth, Long imageHeight, Long fileSizeMb) {
+		boolean isConversionRequired = false;
 
-		if( null == audioRate ) {
-			return true;
-		} else if( audioRate.longValue() > 250000 ) {
-			return true;
-		}
-		if( false == "mp3".equals( audioFormat ) ) {
-			return true;
+		if (audioRate == null
+				|| audioRate > DEFAULT_MAX_BITRATE
+				|| !DEFAULT_REQUIRED_AUDIO_ENCODING.equalsIgnoreCase(audioFormat)
+		) {
+			isConversionRequired = true;
 		}
 
-		return false;
-
+		return isConversionRequired;
 	}
 
 	@Override

--- a/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/DefaultThresholdImage.java
+++ b/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/DefaultThresholdImage.java
@@ -2,49 +2,36 @@ package ca.carleton.gcrc.olkit.multimedia.converter.threshold;
 
 import ca.carleton.gcrc.olkit.multimedia.converter.MultimediaConversionThreshold;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 public class DefaultThresholdImage implements MultimediaConversionThreshold {
 
+	protected static final int DEFAULT_MAX_DIMENSION = 500;
+	protected static final Set<String> DEFAULT_VALID_IMAGE_FORMATS = new HashSet<>(Arrays.asList(
+			"jpg", "jpeg", "gif", "png"));
+
 	@Override
-	public boolean isConversionRequired(
-			String videoFormat
-			,Long videoRate
-			,String audioFormat
-			,Long audioRate
-			,Long imageWidth
-			,Long imageHeight
-			) {
+	public boolean isConversionRequired(String videoFormat, Long videoRate, String audioFormat, Long audioRate,
+										Long imageWidth, Long imageHeight, Long fileSizeMb) {
 
-		if( isResizeRequired(imageWidth, imageHeight) ) {
-			return true;
-		}
-		
-		if( false == "JPEG".equals( videoFormat )
-		 && false == "GIF".equals( videoFormat )
-		 && false == "PNG".equals( videoFormat ) ) {
-			return true;
+		boolean isConversionRequired = false;
+
+		if (isResizeRequired(imageWidth, imageHeight)
+				|| !DEFAULT_VALID_IMAGE_FORMATS.contains(videoFormat.toLowerCase())) {
+			isConversionRequired = true;
 		}
 
-		return false;
+		return isConversionRequired;
 	}
 
 	@Override
 	public boolean isResizeRequired(Long imageWidth, Long imageHeight) {
-		if( null == imageWidth ) {
-			return true;
-		} else if( imageWidth.longValue() > 500 ) {
-			return true;
-		}
-		if( null == imageHeight ) {
-			return true;
-		} else if( imageHeight.longValue() > 500 ) {
-			return true;
-		}
-
-		return false;
+		return imageWidth == null || imageWidth > DEFAULT_MAX_DIMENSION || imageHeight > DEFAULT_MAX_DIMENSION;
 	}
 
 	public String toString() {
 		return this.getClass().getSimpleName();
 	}
-
 }

--- a/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/DefaultThresholdVideo.java
+++ b/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/DefaultThresholdVideo.java
@@ -4,41 +4,34 @@ import ca.carleton.gcrc.olkit.multimedia.converter.MultimediaConversionThreshold
 
 public class DefaultThresholdVideo implements MultimediaConversionThreshold {
 
-	@Override
-	public boolean isConversionRequired(
-			String videoFormat
-			,Long videoRate
-			,String audioFormat
-			,Long audioRate
-			,Long imageWidth
-			,Long imageHeight
-			) {
+	protected static final long DEFAULT_MAX_BITRATE = 250000;
+	protected static final String DEFAULT_REQUIRED_VIDEO_ENCODING = "h264";
+	protected static final String DEFAULT_REQUIRED_AUDIO_ENCODING = "aac";
+	protected static final int DEFAULT_MAX_DIMENSION = 500;
 
-		if( null == videoRate ) {
-			return true;
-			
-		} else if( videoRate.longValue() > 250000 ) {
-			return true;
+	@Override
+	public boolean isConversionRequired(String videoFormat, Long videoRate, String audioFormat, Long audioRate,
+										Long imageWidth, Long imageHeight, Long fileSizeMb) {
+
+		boolean isConversionRequired = false;
+
+		if (videoRate == null
+				|| isResizeRequired(imageWidth, imageHeight)
+				|| videoRate > DEFAULT_MAX_BITRATE
+				|| !DEFAULT_REQUIRED_VIDEO_ENCODING.equalsIgnoreCase(videoFormat)
+				|| !DEFAULT_REQUIRED_AUDIO_ENCODING.equalsIgnoreCase(audioFormat)) {
+			isConversionRequired = true;
 		}
-		
-		if( false == "h264".equals( videoFormat ) ) {
-			return true;
-		}
-		
-		if( false == "mpeg4aac".equals( audioFormat ) ) {
-			return true;
-		}
-		
-		return false;
+
+		return isConversionRequired;
 	}
 
 	@Override
 	public boolean isResizeRequired(Long imageWidth, Long imageHeight) {
-		return false;
+		return imageWidth == null || imageWidth > DEFAULT_MAX_DIMENSION || imageHeight > DEFAULT_MAX_DIMENSION;
 	}
 
 	public String toString() {
 		return this.getClass().getSimpleName();
 	}
-
 }

--- a/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/ThresholdImage.java
+++ b/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/ThresholdImage.java
@@ -10,83 +10,79 @@ import org.slf4j.LoggerFactory;
 
 public class ThresholdImage implements MultimediaConversionThreshold {
 
-	static final protected Logger logger = LoggerFactory.getLogger(ThresholdImage.class);
+	private static final Logger logger = LoggerFactory.getLogger(ThresholdImage.class);
 
-	static public ThresholdImage parseString(String s) {
+	private final String format;
+	private final Long width;
+	private final Long height;
+	private final Long maxFileSizeMb;
+
+	public ThresholdImage(String format, Long width, Long height, Long maxFileSizeMb) {
+		this.format = format;
+		this.width = width;
+		this.height = height;
+		this.maxFileSizeMb = maxFileSizeMb;
+	}
+
+	/**
+	 * Parses a settings string in the format:
+	 * <image-format>,<max-dimension>,<max-file-size>
+	 *
+	 * @param s The settings string to parse.
+	 * @return The object representing image threshold settings.
+	 */
+	public static ThresholdImage parseString(String s) {
 		String[] components = s.split(",");
-		if( 2 == components.length ) {
+		if (components.length == 3) {
 			String format = null;
 			Long size = null;
-			
-			if( false == "*".equals( components[0].trim() ) ) {
+			Long maxFileSize = null;
+
+			if (!"*".equals(components[0].trim())) {
 				format = components[0].trim();
 			}
-			
-			if( false == "*".equals( components[1].trim() ) ) {
-				size = Long.parseLong( components[1].trim() );
+
+			if (!"*".equals(components[1].trim())) {
+				size = Long.parseLong(components[1].trim());
 			}
-			
-			return new ThresholdImage(format, size, size);
-			
-		} else {
-			logger.error("Unable to parse image conversion threshold: "+s);
+
+			// File size
+			if (!"*".equals(components[2].trim())) {
+				maxFileSize = Long.parseLong(components[2].trim());
+			}
+
+			return new ThresholdImage(format, size, size, maxFileSize);
+
+		}
+		else {
+			logger.error("Unable to parse image conversion threshold: {}", s);
 			return null;
 		}
 	}
 	
-	private String format = null;
-	private Long width = null;
-	private Long height = null;
-	
-	public ThresholdImage(String format, Long width, Long height) {
-		this.format = format;
-		this.width = width;
-		this.height = height;
-	}
-	
 	@Override
-	public boolean isConversionRequired(
-			String videoFormat
-			,Long videoRate
-			,String audioFormat
-			,Long audioRate
-			,Long imageWidth
-			,Long imageHeight
-			) {
+	public boolean isConversionRequired(String videoFormat, Long videoRate, String audioFormat, Long audioRate,
+										Long imageWidth, Long imageHeight, Long fileSizeMb) {
 
 		if( isResizeRequired(imageWidth,imageHeight) ) {
 			return true;
 		}
-		
-		if( null != format ) {
-			if( false == format.equals( videoFormat ) ) {
-				return true;
-			}
+
+		if (format != null && !format.equalsIgnoreCase(videoFormat)) {
+			return true;
 		}
-		
-		return false;
+
+		return this.maxFileSizeMb != null && fileSizeMb > maxFileSizeMb;
 	}
 
 	@Override
 	public boolean isResizeRequired(Long imageWidth, Long imageHeight) {
-		
-		if( null != width ) {
-			if( null == imageWidth ) {
-				return true;
-			} else if( imageWidth.longValue() > width.longValue() ) {
-				return true;
-			}
+
+		if (width != null && (imageWidth == null || (imageWidth > width))) {
+			return true;
 		}
-		
-		if( null != height ) {
-			if( null == imageHeight ) {
-				return true;
-			} else if( imageHeight.longValue() > height.longValue() ) {
-				return true;
-			}
-		}
-		
-		return false;
+
+		return height != null && (imageHeight == null || (imageHeight > height));
 	}
 
 	public String toString() {
@@ -116,7 +112,16 @@ public class ThresholdImage implements MultimediaConversionThreshold {
 		} else {
 			pw.print( "*" );
 		}
-		
+
+		pw.print(",");
+
+		if (maxFileSizeMb != null) {
+			pw.println(maxFileSizeMb);
+		}
+		else {
+			pw.print("*");
+		}
+
 		pw.print(")");
 		
 		pw.flush();

--- a/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/ThresholdLogicalAnd.java
+++ b/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/ThresholdLogicalAnd.java
@@ -1,27 +1,26 @@
 package ca.carleton.gcrc.olkit.multimedia.converter.threshold;
 
+import ca.carleton.gcrc.olkit.multimedia.converter.MultimediaConversionThreshold;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
-
-import ca.carleton.gcrc.olkit.multimedia.converter.MultimediaConversionThreshold;
 
 public class ThresholdLogicalAnd implements MultimediaConversionThreshold {
 
-	private List<MultimediaConversionThreshold> children = new Vector<MultimediaConversionThreshold>(); 
+	private List<MultimediaConversionThreshold> children = new ArrayList<>();
 	
 	public void addThreshold(MultimediaConversionThreshold threshold) {
 		children.add(threshold);
 	}
 	
 	@Override
-	public boolean isConversionRequired(String videoFormat, Long videoRate,
-			String audioFormat, Long audioRate, Long imageWidth,
-			Long imageHeight) {
+	public boolean isConversionRequired(String videoFormat, Long videoRate, String audioFormat, Long audioRate,
+										Long imageWidth, Long imageHeight, Long fileSizeMb) {
 
 		for(MultimediaConversionThreshold child : children) {
-			if( false == child.isConversionRequired(videoFormat, videoRate, audioFormat, audioRate, imageWidth, imageHeight) ) {
+			if(!child.isConversionRequired(videoFormat, videoRate, audioFormat, audioRate, imageWidth, imageHeight, fileSizeMb)) {
 				return false;
 			}
 		}
@@ -32,7 +31,7 @@ public class ThresholdLogicalAnd implements MultimediaConversionThreshold {
 	@Override
 	public boolean isResizeRequired(Long imageWidth, Long imageHeight) {
 		for(MultimediaConversionThreshold child : children) {
-			if( false == child.isResizeRequired(imageWidth, imageHeight) ) {
+			if(!child.isResizeRequired(imageWidth, imageHeight)) {
 				return false;
 			}
 		}

--- a/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/utils/MultimediaConfiguration.java
+++ b/nunaliit2-multimedia/src/main/java/ca/carleton/gcrc/olkit/multimedia/utils/MultimediaConfiguration.java
@@ -16,235 +16,264 @@ import ca.carleton.gcrc.olkit.multimedia.ffmpeg.FFmpegProcessorDefault;
 import ca.carleton.gcrc.olkit.multimedia.file.SystemFile;
 import ca.carleton.gcrc.olkit.multimedia.imageMagick.ImageMagickProcessorDefault;
 
-public class MultimediaConfiguration {
+public class MultimediaConfiguration
+{
 
-	static public int IMAGE_MAX_WIDTH = 1000;
-	static public int IMAGE_MAX_HEIGHT = 1000;
-	static public int IMAGE_THUMB_HEIGHT = 350;
-	static public int IMAGE_THUMB_WIDTH = 350;
-	static public int VIDEO_THUMB_HEIGHT = 240;
-	static public int VIDEO_THUMB_WIDTH = 320;
-	
+	private MultimediaConfiguration() {
+	}
+
+	private static int imageMaxWidth = 1000;
+	private static int imageMaxHeight = 1000;
+	private static int imageThumbHeight = 350;
+	private static int imageThumbWidth = 350;
+	private static int videoThumbHeight = 240;
+	private static int videoThumbWidth = 320;
 
 	static final Logger logger = LoggerFactory.getLogger(MultimediaConfiguration.class);
-	
-	static public void configureFromProperties(Properties props) {
-		// FFMpeg
-		{
-			String command = props.getProperty("ffmpegVersionCommand", null);
-			if( null != command ) {
-				FFmpeg.ffmpegVersionCommand = command;
-			}
-		}
-		{
-			String command = props.getProperty("ffmpegInfoCommand", null);
-			if( null != command ) {
-				FFmpegProcessorDefault.ffmpegInfoCommand = command;
-			}
-		}
-		{
-			String command = props.getProperty("ffmpegConvertVideoCommand", null);
-			if( null != command ) {
-				FFmpegProcessorDefault.ffmpegConvertVideoCommand = command;
-			}
-		}
-		{
-			String command = props.getProperty("ffmpegConvertAudioCommand", null);
-			if( null != command ) {
-				FFmpegProcessorDefault.ffmpegConvertAudioCommand = command;
-			}
-		}
-		{
-			String command = props.getProperty("ffmpegCreateThumbnailCommand", null);
-			if( null != command ) {
-				FFmpegProcessorDefault.ffmpegCreateThumbnailCommand = command;
-			}
-		}
-		{
-			String secondsStr = props.getProperty("ffmpegCreateThumbnailFrameInSec", null);
-			if( null != secondsStr ) {
-				try {
-				double seconds = Double.parseDouble(secondsStr.trim());
-				if( seconds < 0 ){
-					throw new Exception("Negative value: "+seconds);
-				}
-				
-				FFmpegProcessorDefault.ffmpegCreateThumbnailFrameInSec = seconds;
 
-				} catch(Exception e) {
-					logger.error("Property 'ffmpegCreateThumbnailFrameInSec' should contain a positive number",e);
+	public static void configureFromProperties(Properties props) {
+		// FFMpeg
+		String ffmpegVersionCommand = props.getProperty("ffmpegVersionCommand", null);
+		if (ffmpegVersionCommand != null) {
+			FFmpeg.ffmpegVersionCommand = ffmpegVersionCommand;
+		}
+
+		String ffmpegInfoCommand = props.getProperty("ffmpegInfoCommand", null);
+		if (ffmpegInfoCommand != null) {
+			FFmpegProcessorDefault.ffmpegInfoCommand = ffmpegInfoCommand;
+		}
+
+		String ffmpegConvertVideoCommand = props.getProperty("ffmpegConvertVideoCommand", null);
+		if (null != ffmpegConvertVideoCommand) {
+			FFmpegProcessorDefault.ffmpegConvertVideoCommand = ffmpegConvertVideoCommand;
+		}
+
+		String ffmpegConvertAudioCommand = props.getProperty("ffmpegConvertAudioCommand", null);
+		if (ffmpegConvertAudioCommand != null) {
+			FFmpegProcessorDefault.ffmpegConvertAudioCommand = ffmpegConvertAudioCommand;
+		}
+
+		String ffmpegCreateThumbnailCommand = props.getProperty("ffmpegCreateThumbnailCommand", null);
+		if (ffmpegCreateThumbnailCommand != null) {
+			FFmpegProcessorDefault.ffmpegCreateThumbnailCommand = ffmpegCreateThumbnailCommand;
+		}
+
+		String secondsStr = props.getProperty("ffmpegCreateThumbnailFrameInSec", null);
+		if (null != secondsStr) {
+			try {
+				double seconds = Double.parseDouble(secondsStr.trim());
+				if (seconds < 0) {
+					throw new Exception("Negative value: " + seconds);
 				}
+
+				FFmpegProcessorDefault.ffmpegCreateThumbnailFrameInSec = seconds;
+			}
+			catch (Exception e) {
+				logger.error("Property 'ffmpegCreateThumbnailFrameInSec' should contain a positive number", e);
 			}
 		}
 
 		// ImageMagick
-		{
-			String command = props.getProperty("imageInfoCommand", null);
-			if( null != command ) {
-				ImageMagickProcessorDefault.imageInfoCommand = command;
-			}
+		String imageInfoCommand = props.getProperty("imageInfoCommand", null);
+		if (imageInfoCommand != null) {
+			ImageMagickProcessorDefault.imageInfoCommand = imageInfoCommand;
 		}
-		{
-			String command = props.getProperty("imageConvertCommand", null);
-			if( null != command ) {
-				ImageMagickProcessorDefault.imageConvertCommand = command;
-			}
+
+		String imageConvertCommand = props.getProperty("imageConvertCommand", null);
+		if (imageConvertCommand != null) {
+			ImageMagickProcessorDefault.imageConvertCommand = imageConvertCommand;
 		}
-		{
-			String command = props.getProperty("imageResizeCommand", null);
-			if( null != command ) {
-				ImageMagickProcessorDefault.imageResizeCommand = command;
-			}
+
+		String imageResizeCommand = props.getProperty("imageResizeCommand", null);
+		if (imageResizeCommand != null) {
+			ImageMagickProcessorDefault.imageResizeCommand = imageResizeCommand;
 		}
-		{
-			String command = props.getProperty("imageReorientCommand", null);
-			if( null != command ) {
-				ImageMagickProcessorDefault.imageReorientCommand = command;
-			}
+
+		String imageReorientCommand = props.getProperty("imageReorientCommand", null);
+		if (imageReorientCommand != null) {
+			ImageMagickProcessorDefault.imageReorientCommand = imageReorientCommand;
 		}
 
 		// Known MIME types
-		{
-			String typeString = props.getProperty("imageMimeTypes", null);
-			if( null != typeString ) {
-				String[] types = typeString.split(":");
-				for(String type : types) {
-					MimeUtils.addKnownImageMimeType(type.trim());
-				}
+		String imageMimeTypes = props.getProperty("imageMimeTypes", null);
+		if (imageMimeTypes != null) {
+			String[] types = imageMimeTypes.split(":");
+			for (String type : types) {
+				MimeUtils.addKnownImageMimeType(type.trim());
 			}
 		}
-		{
-			String typeString = props.getProperty("audioMimeTypes", null);
-			if( null != typeString ) {
-				String[] types = typeString.split(";");
-				for(String type : types) {
-					MimeUtils.addKnownAudioMimeType(type.trim());
-				}
+
+		String audioMimeTypes = props.getProperty("audioMimeTypes", null);
+		if (audioMimeTypes != null) {
+			String[] types = audioMimeTypes.split(";");
+			for (String type : types) {
+				MimeUtils.addKnownAudioMimeType(type.trim());
 			}
 		}
-		{
-			String typeString = props.getProperty("videoMimeTypes", null);
-			if( null != typeString ) {
-				String[] types = typeString.split(";");
-				for(String type : types) {
-					MimeUtils.addKnownVideoMimeType(type.trim());
-				}
+
+		String videoMimeTypes = props.getProperty("videoMimeTypes", null);
+		if (videoMimeTypes != null) {
+			String[] types = videoMimeTypes.split(";");
+			for (String type : types) {
+				MimeUtils.addKnownVideoMimeType(type.trim());
 			}
 		}
-		
+
 		// Image and thumbnail sizes
-		{
-			String sizeString = props.getProperty("imageMaxHeight", null);
-			if( null != sizeString ) {
-				int size = Integer.parseInt(sizeString);
-				IMAGE_MAX_HEIGHT = size;
-			}
+		String imageMaxHeight = props.getProperty("imageMaxHeight", null);
+		if (imageMaxHeight != null) {
+			MultimediaConfiguration.imageMaxHeight = Integer.parseInt(imageMaxHeight);
 		}
-		{
-			String sizeString = props.getProperty("imageMaxWidth", null);
-			if( null != sizeString ) {
-				int size = Integer.parseInt(sizeString);
-				IMAGE_MAX_WIDTH = size;
-			}
+
+		String imageMaxWidth = props.getProperty("imageMaxWidth", null);
+		if (imageMaxWidth != null) {
+			MultimediaConfiguration.imageMaxWidth = Integer.parseInt(imageMaxWidth);
 		}
-		{
-			String sizeString = props.getProperty("thumbnailImageHeight", null);
-			if( null != sizeString ) {
-				int size = Integer.parseInt(sizeString);
-				IMAGE_THUMB_HEIGHT = size;
-			}
+
+		String thumbnailImageHeight = props.getProperty("thumbnailImageHeight", null);
+		if (thumbnailImageHeight != null) {
+			imageThumbHeight = Integer.parseInt(thumbnailImageHeight);
 		}
-		{
-			String sizeString = props.getProperty("thumbnailImageWidth", null);
-			if( null != sizeString ) {
-				int size = Integer.parseInt(sizeString);
-				IMAGE_THUMB_WIDTH = size;
-			}
+
+		String thumbnailImageWidth = props.getProperty("thumbnailImageWidth", null);
+		if (thumbnailImageWidth != null) {
+			imageThumbWidth = Integer.parseInt(thumbnailImageWidth);
 		}
-		{
-			String sizeString = props.getProperty("thumbnailVideoHeight", null);
-			if( null != sizeString ) {
-				int size = Integer.parseInt(sizeString);
-				VIDEO_THUMB_HEIGHT = size;
-			}
+
+		String thumbnailVideoHeight = props.getProperty("thumbnailVideoHeight", null);
+		if (thumbnailVideoHeight != null) {
+			videoThumbHeight = Integer.parseInt(thumbnailVideoHeight);
 		}
-		{
-			String sizeString = props.getProperty("thumbnailVideoWidth", null);
-			if( null != sizeString ) {
-				int size = Integer.parseInt(sizeString);
-				VIDEO_THUMB_WIDTH = size;
-			}
+
+		String thumbnailVideoWidth = props.getProperty("thumbnailVideoWidth", null);
+		if (thumbnailVideoWidth != null) {
+			videoThumbWidth = Integer.parseInt(thumbnailVideoWidth);
 		}
-		
+
 		// Conversion thresholds
-		{
-			String logicalThresholdString = props.getProperty("multimedia.conversion.image.threshold", null);
-			if( null != logicalThresholdString ) {
-				ThresholdLogicalAnd and = new ThresholdLogicalAnd();
-				
-				String[] thresholdStrings = logicalThresholdString.split("\\|");
-				for(String thresholdString : thresholdStrings) {
-					ThresholdImage threshold = ThresholdImage.parseString(thresholdString);
-					and.addThreshold(threshold);
-				}
-				
-				MultimediaConverterImpl.imageConversionThreshold = and;
-				
-				logger.info("Image Conversion Threshold: "+MultimediaConverterImpl.imageConversionThreshold);
-			}
-		}
-		{
-			String logicalThresholdString = props.getProperty("multimedia.conversion.audio.threshold", null);
-			if( null != logicalThresholdString ) {
-				ThresholdLogicalAnd and = new ThresholdLogicalAnd();
-				
-				String[] thresholdStrings = logicalThresholdString.split("\\|");
-				for(String thresholdString : thresholdStrings) {
-					ThresholdAudio threshold = ThresholdAudio.parseString(thresholdString);
-					and.addThreshold(threshold);
-				}
-				
-				MultimediaConverterImpl.audioConversionThreshold = and;
-				
-				logger.info("Audio Conversion Threshold: "+MultimediaConverterImpl.audioConversionThreshold);
-			}
-		}
-		{
-			String logicalThresholdString = props.getProperty("multimedia.conversion.video.threshold", null);
-			if( null != logicalThresholdString ) {
-				ThresholdLogicalAnd and = new ThresholdLogicalAnd();
-				
-				String[] thresholdStrings = logicalThresholdString.split("\\|");
-				for(String thresholdString : thresholdStrings) {
-					ThresholdVideo threshold = ThresholdVideo.parseString(thresholdString);
-					and.addThreshold(threshold);
-				}
-				
-				MultimediaConverterImpl.videoConversionThreshold = and;
-				
-				logger.info("Video Conversion Threshold: "+MultimediaConverterImpl.videoConversionThreshold);
-			}
-		}
-		
+		String imageThresholdString = props.getProperty("multimedia.conversion.image.threshold", null);
+		MultimediaConverterImpl.imageConversionThreshold = parseImageThreshold(imageThresholdString);
+		logger.info("Image Conversion Threshold: {}", MultimediaConverterImpl.imageConversionThreshold);
+
+		String audioThresholdString = props.getProperty("multimedia.conversion.audio.threshold", null);
+		MultimediaConverterImpl.audioConversionThreshold = parseAudioThreshold(audioThresholdString);
+		logger.info("Audio Conversion Threshold: {}", MultimediaConverterImpl.audioConversionThreshold);
+
+		String videoThresholdString = props.getProperty("multimedia.conversion.video.threshold", null);
+		MultimediaConverterImpl.videoConversionThreshold = parseVideoThreshold(videoThresholdString);
+		logger.info("Video Conversion Threshold: {}", MultimediaConverterImpl.videoConversionThreshold);
+
 		// File known strings
-		{
-			Enumeration<?> it = props.propertyNames();
-			while( it.hasMoreElements() ) {
-				Object propertyNameObj = it.nextElement();
-				if( propertyNameObj instanceof String ) {
-					String propertyName = (String)propertyNameObj;
-					if( propertyName.startsWith("file.knownString") ) {
-						String value = props.getProperty(propertyName);
-						// The value should be in the form of <mime-type> : <known string>
-						String[] parts = value.split(":");
-						if( 2 == parts.length ) {
-							SystemFile.addKnownString(parts[0],parts[1]);
-						} else {
-							logger.error("Can not interpret property: "+propertyName+"="+value);
-						}
+		Enumeration<?> it = props.propertyNames();
+		while (it.hasMoreElements()) {
+			Object propertyNameObj = it.nextElement();
+			if (propertyNameObj instanceof String) {
+				String propertyName = (String) propertyNameObj;
+				if (propertyName.startsWith("file.knownString")) {
+					String value = props.getProperty(propertyName);
+					// The value should be in the form of <mime-type> : <known string>
+					String[] parts = value.split(":");
+					if (2 == parts.length) {
+						SystemFile.addKnownString(parts[0], parts[1]);
+					}
+					else {
+						logger.error("Can not interpret property: {}={}", propertyName, value);
 					}
 				}
 			}
 		}
+	}
+
+	/**
+	 * Parses the image threshold property (multimedia.conversion.image.threshold). Example formats:
+	 * - JPEG,500
+	 * - jpeg,500|png,500|gif,500
+	 *
+	 * @param propertyValue The image threshold property to parse.
+	 * @return Threshold configuration for images.
+	 */
+	public static ThresholdLogicalAnd parseImageThreshold(String propertyValue) {
+		ThresholdLogicalAnd thresholdLogicalAnd = null;
+		if (propertyValue != null && propertyValue.length() > 0) {
+			thresholdLogicalAnd = new ThresholdLogicalAnd();
+
+			String[] thresholdStrings = propertyValue.split("\\|");
+			for (String thresholdString : thresholdStrings) {
+				ThresholdImage threshold = ThresholdImage.parseString(thresholdString);
+				thresholdLogicalAnd.addThreshold(threshold);
+			}
+		}
+
+		return thresholdLogicalAnd;
+	}
+
+	/**
+	 * Parses the audio threshold property (multimedia.conversion.audio.threshold). Example formats:
+	 * - mpeg,250000
+	 * - mpeg,250000|ogg,128000
+	 *
+	 * @param propertyValue The audio threshold property to parse.
+	 * @return Threshold configuration for audio.
+	 */
+	public static ThresholdLogicalAnd parseAudioThreshold(String propertyValue) {
+		ThresholdLogicalAnd thresholdLogicalAnd = null;
+		if (propertyValue != null && propertyValue.length() > 0) {
+			thresholdLogicalAnd = new ThresholdLogicalAnd();
+
+			String[] thresholdStrings = propertyValue.split("\\|");
+			for (String thresholdString : thresholdStrings) {
+				ThresholdAudio threshold = ThresholdAudio.parseString(thresholdString);
+				thresholdLogicalAnd.addThreshold(threshold);
+			}
+		}
+
+		return thresholdLogicalAnd;
+	}
+
+	/**
+	 * Parses the video threshold property (multimedia.conversion.video.threshold). Example formats:
+	 * - h264,250000,mpeg4aac,250000,*
+	 * - h264,250000,mpeg4aac,250000,*|mp4,250000,aac,250000,*
+	 *
+	 * @param propertyValue The video threshold property to parse.
+	 * @return Threshold configuration for video.
+	 */
+	public static ThresholdLogicalAnd parseVideoThreshold(String propertyValue) {
+		ThresholdLogicalAnd thresholdLogicalAnd = null;
+		if (propertyValue != null && propertyValue.length() > 0) {
+			thresholdLogicalAnd = new ThresholdLogicalAnd();
+
+			String[] thresholdStrings = propertyValue.split("\\|");
+			for (String thresholdString : thresholdStrings) {
+				ThresholdVideo threshold = ThresholdVideo.parseString(thresholdString);
+				thresholdLogicalAnd.addThreshold(threshold);
+			}
+		}
+
+		return thresholdLogicalAnd;
+	}
+
+	public static int getImageMaxWidth() {
+		return imageMaxWidth;
+	}
+
+	public static int getImageMaxHeight() {
+		return imageMaxHeight;
+	}
+
+	public static int getImageThumbHeight() {
+		return imageThumbHeight;
+	}
+
+	public static int getImageThumbWidth() {
+		return imageThumbWidth;
+	}
+
+	public static int getVideoThumbHeight() {
+		return videoThumbHeight;
+	}
+
+	public static int getVideoThumbWidth() {
+		return videoThumbWidth;
 	}
 }

--- a/nunaliit2-multimedia/src/test/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/ThresholdDummy.java
+++ b/nunaliit2-multimedia/src/test/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/ThresholdDummy.java
@@ -4,8 +4,8 @@ import ca.carleton.gcrc.olkit.multimedia.converter.MultimediaConversionThreshold
 
 public class ThresholdDummy implements MultimediaConversionThreshold {
 
-	private boolean conversionRequired;
-	private boolean resizeRequired;
+	private final boolean conversionRequired;
+	private final boolean resizeRequired;
 	
 	public ThresholdDummy(boolean conversionRequired, boolean resizeRequired) {
 		this.conversionRequired = conversionRequired;
@@ -13,9 +13,8 @@ public class ThresholdDummy implements MultimediaConversionThreshold {
 	}
 	
 	@Override
-	public boolean isConversionRequired(String videoFormat, Long videoRate,
-			String audioFormat, Long audioRate, Long imageWidth,
-			Long imageHeight) {
+	public boolean isConversionRequired(String videoFormat, Long videoRate, String audioFormat, Long audioRate,
+										Long imageWidth, Long imageHeight, Long fileSizeMb) {
 		return conversionRequired;
 	}
 
@@ -23,5 +22,4 @@ public class ThresholdDummy implements MultimediaConversionThreshold {
 	public boolean isResizeRequired(Long imageWidth, Long imageHeight) {
 		return resizeRequired;
 	}
-	
 }

--- a/nunaliit2-multimedia/src/test/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/ThresholdTest.java
+++ b/nunaliit2-multimedia/src/test/java/ca/carleton/gcrc/olkit/multimedia/converter/threshold/ThresholdTest.java
@@ -2,162 +2,162 @@ package ca.carleton.gcrc.olkit.multimedia.converter.threshold;
 
 import junit.framework.TestCase;
 
-public class ThresholdTest extends TestCase {
-
+public class ThresholdTest extends TestCase
+{
 	public void testImageThreshold() {
-		ThresholdImage imageThreshold = ThresholdImage.parseString("JPEG,500");
-		
-		if( true == imageThreshold.isConversionRequired("JPEG", null, null, null, new Long(500), new Long(500)) ) {
+		ThresholdImage imageThreshold = ThresholdImage.parseString("JPEG,500,*");
+
+		if (imageThreshold.isConversionRequired("JPEG", null, null, null, 500L, 500L, 10L)) {
 			fail("Unexpected JPEG/500");
 		}
-		
-		if( false == imageThreshold.isConversionRequired("JPEG", null, null, null, new Long(501), new Long(501)) ) {
+
+		if (!imageThreshold.isConversionRequired("JPEG", null, null, null, 501L, 501L, 10L)) {
 			fail("Unexpected JPEG/501");
 		}
 
-		if( false == imageThreshold.isConversionRequired("PNG", null, null, null, new Long(500), new Long(500)) ) {
+		if (!imageThreshold.isConversionRequired("PNG", null, null, null, 500L, 500L, 10L)) {
 			fail("Unexpected PNG/500");
 		}
 	}
 
 	public void testDefaultImageThreshold() {
 		DefaultThresholdImage imageThreshold = new DefaultThresholdImage();
-		
-		if( true == imageThreshold.isConversionRequired("JPEG", null, null, null, new Long(500), new Long(500)) ) {
-			fail("Unexpected JPEG/500");
-		}
-		
-		if( false == imageThreshold.isConversionRequired("JPEG", null, null, null, new Long(501), new Long(501)) ) {
-			fail("Unexpected JPEG/501");
-		}
 
-		if( true == imageThreshold.isConversionRequired("PNG", null, null, null, new Long(500), new Long(500)) ) {
-			fail("Unexpected PNG/500");
-		}
+		assertFalse(imageThreshold.isConversionRequired(
+				"JPEG", null, null, null, 500L, 500L, 10L));
+
+		assertTrue(imageThreshold.isConversionRequired(
+				"JPEG", null, null, null, 501L, 500L, 10L));
+
+		assertTrue(imageThreshold.isConversionRequired(
+				"BMP", null, null, null, 200L, 200L, 10L));
+
+		assertFalse(imageThreshold.isConversionRequired(
+				"PNG", null, null, null, 500L, 500L, 10L));
+
+		assertFalse(imageThreshold.isConversionRequired(
+				"JPG", null, null, null, 500L, 500L, 10L));
+
+		assertTrue(imageThreshold.isConversionRequired(
+				"JPG", null, null, null, 1000L, 500L, 10L));
 	}
 
 	public void testAudioThreshold() {
-		ThresholdAudio audioThreshold = ThresholdAudio.parseString("mpeg,128000");
-		
-		if( true == audioThreshold.isConversionRequired(null, null, "mpeg", new Long(128000), null, null) ) {
-			fail("Unexpected mpeg/128000");
-		}
-		
-		if( false == audioThreshold.isConversionRequired(null, null, "ogg", new Long(128000), null, null) ) {
-			fail("Unexpected ogg/128000");
+		ThresholdAudio audioThreshold = ThresholdAudio.parseString("mpeg,128000,10");
+
+		if (audioThreshold.isConversionRequired(null, null, "mpeg", 128000L, null, null, 10L)) {
+			fail("Unexpected mpeg/128000/10");
 		}
 
-		if( false == audioThreshold.isConversionRequired(null, null, "mpeg", new Long(128001), null, null) ) {
-			fail("Unexpected mpeg/128001");
+		if (!audioThreshold.isConversionRequired(null, null, "ogg", 128000L, null, null, 10L)) {
+			fail("Unexpected ogg/128000/10");
+		}
+
+		if (!audioThreshold.isConversionRequired(null, null, "mpeg", 128001L, null, null, 10L)) {
+			fail("Unexpected mpeg/128001/10");
+		}
+
+		if (!audioThreshold.isConversionRequired(null, null, "mpeg", 128000L, null, null, 20L)) {
+			fail("Unexpected mpeg/128000/20");
 		}
 	}
 
 	public void testDefaultAudioThreshold() {
 		DefaultThresholdAudio audioThreshold = new DefaultThresholdAudio();
-		
-		if( true == audioThreshold.isConversionRequired(null, null, "mp3", new Long(250000), null, null) ) {
-			fail("Unexpected mp3/250000");
-		}
-		
-		if( false == audioThreshold.isConversionRequired(null, null, "ogg", new Long(250000), null, null) ) {
-			fail("Unexpected ogg/250000");
-		}
 
-		if( false == audioThreshold.isConversionRequired(null, null, "mp3", new Long(250001), null, null) ) {
-			fail("Unexpected mp3/250001");
-		}
+		assertFalse("Unexpected aac/250000", audioThreshold.isConversionRequired(
+				null, null, DefaultThresholdAudio.DEFAULT_REQUIRED_AUDIO_ENCODING, 250000L, null, null, 10L));
+
+		assertTrue("Unexpected ogg/250000", audioThreshold.isConversionRequired(
+				null, null, "ogg", 250000L, null, null, 10L));
+
+		assertTrue("Unexpected aac/250001", audioThreshold.isConversionRequired(
+				null, null, DefaultThresholdAudio.DEFAULT_REQUIRED_AUDIO_ENCODING, 250001L, null, null, 10L));
 	}
 
 	public void testVideoThreshold() {
-		ThresholdVideo videoThreshold = ThresholdVideo.parseString("h264,250000,mpeg4aac,250000,500");
-		
-		if( true == videoThreshold.isConversionRequired("h264", new Long(250000), "mpeg4aac", new Long(250000), new Long(500), new Long(500)) ) {
-			fail("Unexpected h264/250000/mpeg4acc/250000/500");
-		}
+		ThresholdVideo videoThreshold = ThresholdVideo.parseString("h264,250000,mpeg4aac,250000,500,10");
 
-		if( false == videoThreshold.isConversionRequired("video", new Long(250000), "mpeg4aac", new Long(250000), new Long(500), new Long(500)) ) {
-			fail("Unexpected video/250000/mpeg4acc/250000/500");
-		}
+		assertFalse("Unexpected h264/250000/mpeg4aac/250000/500", videoThreshold.isConversionRequired(
+				"h264", 250000L, "mpeg4aac", 250000L, 500L, 500L, 10L));
 
-		if( false == videoThreshold.isConversionRequired("h264", new Long(250001), "mpeg4aac", new Long(250000), new Long(500), new Long(500)) ) {
-			fail("Unexpected h264/250001/mpeg4acc/250000/500");
-		}
+		assertTrue("Unexpected video/250000/mpeg4aac/250000/500", videoThreshold.isConversionRequired(
+				"video", 250000L, "mpeg4aac", 250000L, 500L, 500L, 10L));
 
-		if( false == videoThreshold.isConversionRequired("h264", new Long(250000), "audio", new Long(250000), new Long(500), new Long(500)) ) {
-			fail("Unexpected h264/250000/audio/250000/500");
-		}
+		assertTrue("Unexpected h264/250001/mpeg4aac/250000/500", videoThreshold.isConversionRequired(
+				"h264", 250001L, "mpeg4aac", 250000L, 500L, 500L, 10L));
 
-		if( false == videoThreshold.isConversionRequired("h264", new Long(250000), "mpeg4aac", new Long(250001), new Long(500), new Long(500)) ) {
-			fail("Unexpected h264/250000/mpeg4acc/250001/500");
-		}
+		assertTrue("Unexpected h264/250000/mpeg4aac/250000/500", videoThreshold.isConversionRequired(
+				"h264", 250000L, "audio", 250000L, 500L, 500L, 10L));
 
-		if( false == videoThreshold.isConversionRequired("h264", new Long(250000), "mpeg4aac", new Long(250000), new Long(501), new Long(501)) ) {
-			fail("Unexpected h264/250000/mpeg4acc/250000/501");
-		}
+		assertTrue("Unexpected h264/250000/mpeg4aac/250001/500", videoThreshold.isConversionRequired(
+				"h264", 250000L, "mpeg4aac", 250001L, 500L, 500L, 10L));
+
+		assertTrue("Unexpected h264/250000/mpeg4aac/250000/501", videoThreshold.isConversionRequired(
+				"h264", 250000L, "mpeg4aac", 250000L, 501L, 501L, 10L));
+
+		assertTrue("Unexpected h264/250000/mpeg4aac/250000/500", videoThreshold.isConversionRequired(
+				"h264", 250000L, "mpeg4aac", 250000L, 500L, 500L, 11L));
 	}
 
 	public void testDefaultVideoThreshold() {
 		DefaultThresholdVideo videoThreshold = new DefaultThresholdVideo();
-		
-		if( true == videoThreshold.isConversionRequired("h264", new Long(250000), "mpeg4aac", new Long(250000), new Long(500), new Long(500)) ) {
-			fail("Unexpected h264/250000/mpeg4acc/250000/500");
-		}
 
-		if( false == videoThreshold.isConversionRequired("video", new Long(250000), "mpeg4aac", new Long(250000), new Long(500), new Long(500)) ) {
-			fail("Unexpected video/250000/mpeg4acc/250000/500");
-		}
+		assertFalse("Unexpected h264/250000/aac/250000/500", videoThreshold.isConversionRequired(
+				"h264", 250000L, DefaultThresholdVideo.DEFAULT_REQUIRED_AUDIO_ENCODING, 250000L, 500L, 500L, 10L));
 
-		if( false == videoThreshold.isConversionRequired("h264", new Long(250001), "mpeg4aac", new Long(250000), new Long(500), new Long(500)) ) {
-			fail("Unexpected h264/250001/mpeg4acc/250000/500");
-		}
+		assertTrue("Unexpected video/250000/aac/250000/500", videoThreshold.isConversionRequired(
+				"video", 250000L, DefaultThresholdVideo.DEFAULT_REQUIRED_AUDIO_ENCODING, 250000L, 500L, 500L, 10L));
 
-		if( false == videoThreshold.isConversionRequired("h264", new Long(250000), "audio", new Long(250000), new Long(500), new Long(500)) ) {
-			fail("Unexpected h264/250000/audio/250000/500");
-		}
+		assertTrue("Unexpected h264/250001/aac/250000/500", videoThreshold.isConversionRequired(
+				"h264", 250001L, DefaultThresholdVideo.DEFAULT_REQUIRED_AUDIO_ENCODING, 250000L, 500L, 500L, 10L));
+
+		assertTrue("Unexpected h264/250000/audio/250000/500", videoThreshold.isConversionRequired(
+				"h264", 250000L, "audio", 250000L, 500L, 500L, 10L));
 	}
-	
+
 	public void testLogicalAnd() {
 		ThresholdDummy tTrue = new ThresholdDummy(true, true);
 		ThresholdDummy tFalse = new ThresholdDummy(false, false);
-		
+
 		{
 			ThresholdLogicalAnd and = new ThresholdLogicalAnd();
 			and.addThreshold(tTrue);
 			and.addThreshold(tTrue);
-			
-			if( false == and.isConversionRequired(null, null, null, null, null, null) ) {
+
+			if (!and.isConversionRequired(null, null, null, null, null, null, 10L)) {
 				fail("Conversion true-true");
 			}
-			
-			if( false == and.isResizeRequired(null, null) ) {
+
+			if (!and.isResizeRequired(null, null)) {
 				fail("Resize true-true");
 			}
 		}
-		
+
 		{
 			ThresholdLogicalAnd and = new ThresholdLogicalAnd();
 			and.addThreshold(tFalse);
 			and.addThreshold(tFalse);
-			
-			if( true == and.isConversionRequired(null, null, null, null, null, null) ) {
+
+			if (and.isConversionRequired(null, null, null, null, null, null, 10L)) {
 				fail("Conversion false-false");
 			}
-			
-			if( true == and.isResizeRequired(null, null) ) {
+
+			if (and.isResizeRequired(null, null)) {
 				fail("Resize false-false");
 			}
 		}
-		
+
 		{
 			ThresholdLogicalAnd and = new ThresholdLogicalAnd();
 			and.addThreshold(tFalse);
 			and.addThreshold(tTrue);
-			
-			if( true == and.isConversionRequired(null, null, null, null, null, null) ) {
+
+			if (and.isConversionRequired(null, null, null, null, null, null, 10L)) {
 				fail("Conversion false-true");
 			}
-			
-			if( true == and.isResizeRequired(null, null) ) {
+
+			if (and.isResizeRequired(null, null)) {
 				fail("Resize false-true");
 			}
 		}

--- a/nunaliit2-multimedia/src/test/java/ca/carleton/gcrc/olkit/multimedia/utils/MultimediaConfigurationTest.java
+++ b/nunaliit2-multimedia/src/test/java/ca/carleton/gcrc/olkit/multimedia/utils/MultimediaConfigurationTest.java
@@ -1,0 +1,108 @@
+package ca.carleton.gcrc.olkit.multimedia.utils;
+
+import ca.carleton.gcrc.olkit.multimedia.converter.threshold.ThresholdLogicalAnd;
+import junit.framework.TestCase;
+
+import java.util.Properties;
+
+/**
+ * Test the multimedia threshold properties. Specifically, when a threshold is not configured, when it has one threshold
+ * setting, and when it has two threshold settings.
+ */
+public class MultimediaConfigurationTest extends TestCase
+{
+	public void testConfigureFromProperties_imageThresholdNone() {
+		Properties props = new Properties();
+		ThresholdLogicalAnd threshold = MultimediaConfiguration.parseImageThreshold(props.getProperty(
+				"multimedia.conversion.image.threshold", null));
+
+		assertNull(threshold);
+	}
+
+	public void testConfigureFromProperties_imageThresholdOne() {
+		Properties props = new Properties();
+		props.setProperty("multimedia.conversion.image.threshold", "jpeg,500,*");
+		ThresholdLogicalAnd threshold = MultimediaConfiguration.parseImageThreshold(props.getProperty(
+				"multimedia.conversion.image.threshold", null));
+
+		assertNotNull(threshold);
+		assertFalse(threshold.isConversionRequired("JPEG", null, null, null, 500L, 400L, 10000000L));
+	}
+
+	public void testConfigureFromProperties_imageThresholdTwo() {
+		Properties props = new Properties();
+		props.setProperty("multimedia.conversion.image.threshold", "jpeg,500,*|PNG,1000,10");
+		ThresholdLogicalAnd threshold = MultimediaConfiguration.parseImageThreshold(props.getProperty(
+				"multimedia.conversion.image.threshold", null));
+
+		assertNotNull(threshold);
+		assertFalse(threshold.isConversionRequired("JPEG", null, null, null, 500L, 400L, 100000L));
+		assertFalse(threshold.isConversionRequired("png", null, null, null, 1000L, 1000L, 10L));
+		assertTrue(threshold.isConversionRequired("png", null, null, null, 1200L, 1000L, 10L));
+		assertTrue(threshold.isConversionRequired("png", null, null, null, 1000L, 1000L, 11L));
+	}
+
+	public void testConfigureFromProperties_audioThresholdNone() {
+		Properties props = new Properties();
+		ThresholdLogicalAnd threshold = MultimediaConfiguration.parseAudioThreshold(props.getProperty(
+				"multimedia.conversion.audio.threshold", null));
+
+		assertNull(threshold);
+	}
+
+	public void testConfigureFromProperties_audioThresholdOne() {
+		Properties props = new Properties();
+		props.setProperty("multimedia.conversion.audio.threshold", "mpeg,128000,*");
+		ThresholdLogicalAnd threshold = MultimediaConfiguration.parseAudioThreshold(props.getProperty(
+				"multimedia.conversion.audio.threshold", null));
+
+		assertNotNull(threshold);
+		assertFalse(threshold.isConversionRequired(null, null, "mpeg", 128000L, null, null, 1000L));
+		assertTrue(threshold.isConversionRequired(null, null, "ogg", 128000L, null, null, 1000L));
+	}
+
+	public void testConfigureFromProperties_audioThresholdTwo() {
+		Properties props = new Properties();
+		props.setProperty("multimedia.conversion.audio.threshold", "mpeg,128000,*|ogg,130000,10");
+		ThresholdLogicalAnd threshold = MultimediaConfiguration.parseAudioThreshold(props.getProperty(
+				"multimedia.conversion.audio.threshold", null));
+
+		assertNotNull(threshold);
+		assertFalse(threshold.isConversionRequired(null, null, "mpeg", 128000L, null, null, 10L));
+		assertFalse(threshold.isConversionRequired(null, null, "ogg", 130000L, null, null, 10L));
+		assertTrue(threshold.isConversionRequired(null, null, "ogg", 140000L, null, null, 10L));
+		assertTrue(threshold.isConversionRequired(null, null, "ogg", 130000L, null, null, 30L));
+	}
+
+	public void testConfigureFromProperties_videoThresholdNone() {
+		Properties props = new Properties();
+		ThresholdLogicalAnd threshold = MultimediaConfiguration.parseVideoThreshold(props.getProperty(
+				"multimedia.conversion.video.threshold", null));
+
+		assertNull(threshold);
+	}
+
+	public void testConfigureFromProperties_videoThresholdOne() {
+		Properties props = new Properties();
+		props.setProperty("multimedia.conversion.video.threshold", "h264,250000,aac,250000,*,*");
+		ThresholdLogicalAnd threshold = MultimediaConfiguration.parseVideoThreshold(props.getProperty(
+				"multimedia.conversion.video.threshold", null));
+
+		assertNotNull(threshold);
+		assertFalse(threshold.isConversionRequired("h264", 250000L, "aac", 128000L, 480L, 320L, 10L));
+		assertTrue(threshold.isConversionRequired("h264", 250000L, "wav", 128000L, 2440L, 1080L, 10L));
+	}
+
+	public void testConfigureFromProperties_videoThresholdTwo() {
+		Properties props = new Properties();
+		props.setProperty("multimedia.conversion.video.threshold", "h264,250000,aac,250000,*,*|mp4,128000,aac,128000,2440,1000");
+		ThresholdLogicalAnd threshold = MultimediaConfiguration.parseVideoThreshold(props.getProperty(
+				"multimedia.conversion.video.threshold", null));
+
+		assertNotNull(threshold);
+		assertFalse(threshold.isConversionRequired("h264", 250000L, "aac", 128000L, 480L, 320L, 10L));
+		assertFalse(threshold.isConversionRequired("mp4", 128000L, "aac", 128000L, 480L, 320L, 10L));
+		assertTrue(threshold.isConversionRequired("h264", 250000L, "wav", 128000L, 2440L, 1080L, 10L));
+		assertTrue(threshold.isConversionRequired("mp4", 128000L, "aac", 128000L, 2445L, 500L, 1000L));
+	}
+}


### PR DESCRIPTION
Some minor changes to the existing framework to configure image/audio/video threshold settings in multimedia.properties:

- Added maximum file size (MB) to each setting;
- Updated documentation in the code, in `multimedia.properties` and at https://github.com/GCRC/nunaliit/wiki/Nunaliit-Documentation-for-Atlas-Builders#configuration_multimedia
- Added tests and cleaned up some code. (sorry the review is messy because of the cleanup)