### PR TITLE
Schema Join Model Transform

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.modelUtils.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.modelUtils.js
@@ -505,11 +505,11 @@ var ModelIntersect = $n2.Class({
  * '_<schema-name>' key.
  *
  * @param {string} sourceModelId - Id of the source model.
- * @param {array} batchJoins - list of joins between different schemas. Note:
+ * @param {array} joins - list of joins between different schemas. Note:
  * joins are perfomed in the order they are listed, and join transforms persist
- * between each batch process.
+ * between each process.
  * Example:
- * 		"batchJoins": [
+ * 		"joins": [
  * 			{
  * 				"leftSchema": "testatlas_account",
  * 				"leftJoinField": "doc.testatlas_account.bank.doc",
@@ -529,8 +529,8 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 	modelType: null,
 	dispatchService: null,
 	sourceModelId: null,
-	batchNum: null,
-	batchJoins: null,
+	joinNum: null,
+	joins: null,
 	leftSchema: null,
 	rightSchema: null,
 	leftJoinField: null,
@@ -551,8 +551,8 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 			sourceModelId: null,
 			informationModelIds: null,
 			dispatchService: null,
-			batchNum: 0,
-			batchJoins: null
+			joinNum: 0,
+			joins: null
 		},opts_);
 
 		var _this = this;
@@ -562,17 +562,17 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 		this.modelIsLoading = false;
 		this.dispatchService = opts.dispatchService;
 		this.sourceModelId = opts.sourceModelId;
-		this.batchNum = opts.batchNum;
+		this.joinNum = opts.joinNum;
 
-		if ($n2.isArray(opts.batchJoins)
-			&& opts.batchJoins.length) {
-			this.batchJoins = opts.batchJoins;
+		if ($n2.isArray(opts.joins)
+			&& opts.joins.length) {
+			this.joins = opts.joins;
 
 			// Set the initial left and right schemas to which need to be joined
-			this._setLeftRightSchemas(this.batchJoins[this.batchNum]);
+			this._setLeftRightSchemas(this.joins[this.joinNum]);
 
 		} else {
-			throw new Error('batchJoins needs to be an array.');
+			throw new Error('Joins needs to be an array.');
 		}
 
 		this.addedMap = {};
@@ -697,7 +697,7 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 		this.updatedMap = {};
 		this.removedMap = {};
 		this.schemaDocsByDocId.length = 0;
-		this.batchNum = 0;
+		this.joinNum = 0;
 
 		if (typeof sourceState.loading === 'boolean'
 			&& this.modelIsLoading !== sourceState.loading) {
@@ -841,9 +841,9 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 
 		// perform next batch of schema join conditions
 		if (!this.modelIsLoading
-			&& this.batchNum < this.batchJoins.length - 1) {
-			this.batchNum += 1;
-			this._setLeftRightSchemas(this.batchJoins[this.batchNum]);
+			&& this.joinNum < this.joins.length - 1) {
+			this.joinNum += 1;
+			this._setLeftRightSchemas(this.joins[this.joinNum]);
 			this._joinSchemaDocs();
 
 		} else {

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.modelUtils.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.modelUtils.js
@@ -1076,7 +1076,7 @@ function handleModelCreate(m, addr, dispatcher){
 		
 		m.created = true;
 
-	} else if (m.modelType === 'schemajoin') {
+	} else if (m.modelType === 'schemaDocsJoin') {
 		var optionKeys, i, key;
 		var options = {};
 		

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.modelUtils.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.modelUtils.js
@@ -497,7 +497,7 @@ var ModelIntersect = $n2.Class({
 	}
 });
 
-/* 
+/*
  * @class
  * A model transform which joins multiple documents of different schemas based
  * on supplied join fields. This transformation functions by copying the copy
@@ -541,13 +541,13 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 	updatedMap: null,
 	removedMap: null,
 	docInfosByDocId: null,
-	schemaDocsByDocId: null, 
-	copyToSchemaDocsByDocId: null, 
-	copyFromSchemaDocsByDocId: null, 
+	schemaDocsByDocId: null,
+	copyToSchemaDocsByDocId: null,
+	copyFromSchemaDocsByDocId: null,
 	modelIsLoading: null,
 
 	initialize: function(opts_) {
-		var f, m;
+		var dispatchFn, msg;
 		var opts = $n2.extend({
 			modelId: null,
 			sourceModelId: null,
@@ -587,23 +587,23 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 
 		// Register to events
 		if (this.dispatchService) {
-			f = function(m, addr, dispatcher) {
+			dispatchFn = function(m, addr, dispatcher) {
 				_this._handle(m, addr, dispatcher);
 			};
 
-			this.dispatchService.register(DH, 'modelGetInfo', f);
-			this.dispatchService.register(DH, 'modelGetState', f);
-			this.dispatchService.register(DH, 'modelStateUpdated', f);
+			this.dispatchService.register(DH, 'modelGetInfo', dispatchFn);
+			this.dispatchService.register(DH, 'modelGetState', dispatchFn);
+			this.dispatchService.register(DH, 'modelStateUpdated', dispatchFn);
 
 			// Initialize state
-			m = {
+			msg = {
 				type: 'modelGetState',
 				modelId: this.sourceModelId
 			};
 
-			this.dispatchService.synchronousCall(DH, m);
-			if (m.state) {
-				this._sourceModelUpdated(m.state);
+			this.dispatchService.synchronousCall(DH, msg);
+			if (msg.state) {
+				this._sourceModelUpdated(msg.state);
 			}
 		}
 
@@ -699,21 +699,8 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 		return modelInfo;
 	},
 
-	_cloneDocument: function(doc) {
-		var key, value;
-		var clone = {};
-
-		for (key in doc) {
-			if (Object.prototype.hasOwnProperty.call(doc,key)) {
-				value = doc[key];
-				clone[key] = value;
-			}
-		}
-		return clone;
-	},
-
 	_sourceModelUpdated: function(sourceState) {
-		var i, e, doc, docId, docInfo, schema;
+		var i, e, doc, docId, docInfo;
 		var added, updated, removed, schema, schemaDocs;
 		var processingRequired = false;
 		this.addedMap = {};
@@ -923,7 +910,7 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 			}
 
 		} else {
-			// Check final property in object, and handle if its a string, 
+			// Check final property in object, and handle if its a string,
 			// array, or document reference.
 			if (Object.hasOwnProperty.call(obj, firstKey)) {
 				keyValue = obj[firstKey];
@@ -954,7 +941,7 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 
 	// Get specific key content from copyFrom schema document.
 	_copyKeyContent: function(doc) {
-		var i, key, keyValue, copiedKeys;
+		var i, key, keyValue;
 		var copiedKeysObj = {};
 
 		for (i = 0; i < this.keysToCopy.length; i += 1) {
@@ -972,7 +959,7 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 	_computeTransform: function(doc) {
 		var i, j, copyToJoinVal;
 		var docId, copyFromDoc, copyFromDocs, copyFromJoinVal;
-		var transformed = this._cloneDocument(doc);
+		var transformed = $n2.deepCopy(doc);
 
 		// Get copy to schema document join value if available
 		copyToJoinVal = this._getKeyValues(doc, this.copyToJoinKey);

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.modelUtils.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.modelUtils.js
@@ -497,8 +497,18 @@ var ModelIntersect = $n2.Class({
 	}
 });
 
-//--------------------------------------------------------------------------
-
+// --------------------------------------------------------------------------
+/* 
+ * @class
+ * A model transform which joins multiple documents based on schema. 
+ *
+ * @param {string} [name] desc
+ * @param {string} sourceModelId - Id of the source model
+ * @param {string} leftSchema - Name of the left schema. e.g. 'demo_account'.
+ * @param {string} leftJoinField - The field in the schema used for joining. e.g. 'doc.demo_account.person_ref.doc`
+ * @param {string} rightSchema - Name of the right schema. e.g. 'demo_person'.
+ * @param {string} rightJoinField - The field in the schema used for joining. e.g. 'doc._id'.
+ */
 var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 
 	modelType: null,

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.modelUtils.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.modelUtils.js
@@ -893,20 +893,16 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 		var keysSplit = keyString.split('.');
 		var firstKey = keysSplit.shift();
 
-		if (!Object.hasOwnProperty.call(obj, firstKey)) {
-			// Add object property if it doesn't exist.
-			if (keysSplit.length) {
+		if (keysSplit.length) {
+			if (!Object.hasOwnProperty.call(obj, firstKey)) {
+				// Add object property if it doesn't exist.
 				obj[firstKey] = {};
 				this._updateObjWithKeyString(obj[firstKey], keysSplit.join('.'), keyValue);
 			} else {
-				obj[firstKey] = keyValue;
+				this._updateObjWithKeyString(obj[firstKey], keysSplit.join('.'), keyValue);
 			}
 		} else {
-			if (keysSplit.length) {
-				this._updateObjWithKeyString(obj[firstKey], keysSplit.join('.'), keyValue);
-			} else {
-				obj[firstKey] = keyValue;
-			}
+			obj[firstKey] = keyValue;
 		}
 	},
 
@@ -914,24 +910,23 @@ var ModelSchemaJoinTransform = $n2.Class('ModelSchemaJoinTransform', {
 	// If the object doesn't have the key, it returns false.
 	_getKeyValues: function(obj, keyString) {
 		var i, value, keyValue, item, itemValue;
-		var props = keyString.split('.');
-		var firstProp = props.shift();
+		var keysSplit = keyString.split('.');
+		var firstKey = keysSplit.shift();
 
-		if (props.length) {
-			if (Object.hasOwnProperty.call(obj, firstProp)) {
-				// Check next property in props list
-				value = this._getKeyValues(obj[firstProp], props.join('.'));
+		if (keysSplit.length) {
+			if (Object.hasOwnProperty.call(obj, firstKey)) {
+				// Check next property in keysSplit list
+				value = this._getKeyValues(obj[firstKey], keysSplit.join('.'));
 			} else {
 				// Object doesn't include property
 				value = false;
 			}
 
 		} else {
-			// Check final property in object.
-			// if a string, return the string otherwise check if its a
-			// Nunaliit reference object, with a doc key.
-			if (Object.hasOwnProperty.call(obj, firstProp)) {
-				keyValue = obj[firstProp];
+			// Check final property in object, and handle if its a string, 
+			// array, or document reference.
+			if (Object.hasOwnProperty.call(obj, firstKey)) {
+				keyValue = obj[firstKey];
 				if (this._isNunaliitRefObj(keyValue)) {
 					value = keyValue.doc;
 				} else if (typeof keyValue === 'string') {


### PR DESCRIPTION
**Schema Join Model Transform**

**Purpose**: Nunaliit atlases often have data broken up across multiple document, which are related to each other through references. When working on data visualizations, we often need to see related document content to perform tasks on the data. This model transform attempts to simplify this process, by creating a generic way of transforming documents to include the contents of related documents, in the transformed document, for easier access. This transformation is loosely inspired by a left outer SQL join, but uses schema documents, and also doesn't exclude right outer documents in the final result since these may still be needed further down the model chain.

**Example**: An atlas contains 3 schemas; a bank schema, a person schema, and an account schema. Each account schema contains a reference to both a bank document and a person document. Using this transform, you could transform the account schema to include a copy of the contents of the bank schema and person schema, to allow easier access to that related content. 

model.json
```javascript
[
	{
		"modelId": "documentModel",
		"modelType": "couchDbDataSource",
		"selectors": [
			{
				"name": {
					"en": "Test Atlas Person",
					"nunaliit_type": "localized"
				},
				"options": {"schemaName": "testatlas_person"},
				"type": "couchDbSchema",
				"visibility": true
			},
			{
				"name": {
					"en": "Test Atlas Bank",
					"nunaliit_type": "localized"
				},
				"options": {"schemaName": "testatlas_bank"},
				"type": "couchDbSchema",
				"visibility": true
			},
			{
				"name": {
					"en": "Test Atlas Account",
					"nunaliit_type": "localized"
				},
				"options": {
					"schemaName": "testatlas_account"
				},
				"type": "couchDbSchema",
				"visibility": true
			}
		]
	},
	{
		"modelId": "joinedDocs",
		"modelType": "schemaDocsJoin",
		"sourceModelId": "documentModel",
		"joins": [
			{
				"copyToSchema": "testatlas_account",
				"copyToJoinKey": "testatlas_account.bank.doc",
				"copyFromSchema": "testatlas_bank",
				"copyFromJoinKey": "_id",
				"keysToCopy": [
					"_id",
					"testatlas_bank.name"
				]
			},
			{
				"copyToSchema": "testatlas_account",
				"copyToJoinKey": "testatlas_account.person",
				"copyFromSchema": "testatlas_person",
				"copyFromJoinKey": "_id"
			}
		]
	}
]
```
