### PR TITLE
Fix #916: Add trailing slash to schema.org URL in JSON-LD. Required f…

### DIFF
--- a/nunaliit2-couch-application/src/main/atlas_couchapp/_attachments/tools/js/metadata.js
+++ b/nunaliit2-couch-application/src/main/atlas_couchapp/_attachments/tools/js/metadata.js
@@ -35,7 +35,7 @@
         '          "@type": "Place"\n' +
         '        },\n' +
         '        "@context": {\n' +
-        '          "@vocab": "http://schema.org"\n' +
+        '          "@vocab": "http://schema.org/"\n' +
         '        },\n' +
         '        "url": ""\n' +
         '      }');

--- a/nunaliit2-couch-application/src/main/updateDocs/org.nunaliit.schema.atlas/create.json
+++ b/nunaliit2-couch-application/src/main/updateDocs/org.nunaliit.schema.atlas/create.json
@@ -34,7 +34,7 @@
         "@type": "Place"
       },
       "@context": {
-        "@vocab": "http://schema.org"
+        "@vocab": "http://schema.org/"
       },
       "url": ""
     }

--- a/nunaliit2-couch-application/src/main/updateDocs/org.nunaliit.schema.metadata/create.json
+++ b/nunaliit2-couch-application/src/main/updateDocs/org.nunaliit.schema.metadata/create.json
@@ -28,7 +28,7 @@
          "@type": "Place"
       },
       "@context": {
-         "@vocab": "http://schema.org"
+         "@vocab": "http://schema.org/"
       },
       "url": ""
    }

--- a/nunaliit2-couch-application/src/main/updateDocs/org.nunaliit.schema.module/create.json
+++ b/nunaliit2-couch-application/src/main/updateDocs/org.nunaliit.schema.module/create.json
@@ -54,7 +54,7 @@
 				"@type": "Place"
 			},
 			"@context": {
-				"@vocab": "http://schema.org"
+				"@vocab": "http://schema.org/"
 			},
 			"url": ""
 		}

--- a/nunaliit2-couch-metadata/src/test/resources/atlas/with_metadata.json
+++ b/nunaliit2-couch-metadata/src/test/resources/atlas/with_metadata.json
@@ -92,7 +92,7 @@
         "@type": "Place"
       },
       "@context": {
-        "@vocab": "http://schema.org"
+        "@vocab": "http://schema.org/"
       },
       "url": "http://localhost:8081"
     }

--- a/nunaliit2-couch-sdk/src/main/content/docs/atlas/nunaliit_atlas.json
+++ b/nunaliit2-couch-sdk/src/main/content/docs/atlas/nunaliit_atlas.json
@@ -59,7 +59,7 @@
       "@type": "Place"
     },
     "@context": {
-      "@vocab": "http://schema.org"
+      "@vocab": "http://schema.org/"
     },
     "url": ""
   }


### PR DESCRIPTION
Add trailing slash to schema.org URL in JSON-LD. Required for compliance.