### PR TITLE
Issue 924: Expanded Conditional Model Filter

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.modelFilter.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.modelFilter.js
@@ -2231,8 +2231,15 @@ function handleModelCreate(m, addr, dispatcher){
 		var module = m.moduleDisplay.module;
 		
 		var mapInfo = module.getMapInfo();
-		
-		options.rules = mapInfo.styles;
+
+		// Check if mapInfo object exists
+		if (mapInfo) {
+			options.rules = mapInfo.styles;
+		} else {
+			// If no mapInfo object exists, try to get canvasInfo.
+			var canvasInfo = module.getCanvasInfo();
+			options.rules = canvasInfo.styles;
+		}
 		
 		if( m && m.config ){
 			if( m.config.directory ){


### PR DESCRIPTION
Expand the conditional model filter to get canvasInfo when no mapInfo object is available. 

This change addresses the issue of the conditional filter doesn't work with canvases of type map.
 
fix #924 