### PR TITLE
Add basic parsing for InReach form number type

### DIFF
--- a/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/CommandInReachSchemaDefs.java
+++ b/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/CommandInReachSchemaDefs.java
@@ -145,6 +145,9 @@ public class CommandInReachSchemaDefs implements Command {
 				attribute.put("type", "string");
 				attribute.put("textarea", true);
 
+			} else if( InReachFormField.Type.NUMBER == fieldType) {	
+				attribute.put("type", "string");
+
 			} else {
 				throw new Exception("Unexpected field type: "+fieldType);
 			}

--- a/nunaliit2-couch-onUpload/src/main/java/ca/carleton/gcrc/couch/onUpload/inReach/InReachFormField.java
+++ b/nunaliit2-couch-onUpload/src/main/java/ca/carleton/gcrc/couch/onUpload/inReach/InReachFormField.java
@@ -6,7 +6,8 @@ public interface InReachFormField {
 	
 	public enum Type {
 		PICKLIST("PickList"),
-		TEXT("Text");
+		TEXT("Text"),
+		NUMBER("Number");
 		
 		private String label;
 		private Type(String label){


### PR DESCRIPTION
Parses the Number field in InReach XML forms.
Stored as string in JSON.

closes #951 