### PR TITLE
Bump up node and npm versions

### DIFF
--- a/nunaliit2-js/pom.xml
+++ b/nunaliit2-js/pom.xml
@@ -90,8 +90,8 @@
 						<goal>install-node-and-npm</goal>
 					</goals>
 					<configuration>
-						<nodeVersion>v16.14.2</nodeVersion>
-						<npmVersion>8.5.0</npmVersion>
+						<nodeVersion>v16.19.0</nodeVersion>
+						<npmVersion>9.3.1</npmVersion>
 						<installDirectory>tools</installDirectory>
 					</configuration>
 				</execution>


### PR DESCRIPTION
Node 16.x appears to be latest version still supported in Ubuntu 18.04 so I used that. Latest npm 9.3.1 works. Tested building in both Ubuntu 18.04 and 20.04 using openjdk 8 and openjdk 11 respectively. Tested deploying to n2test atlas on 18.04.