### PR TITLE
965 schemas for inreach cmd populate schema folder

### DIFF
--- a/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/CommandInReachSchemaDefs.java
+++ b/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/CommandInReachSchemaDefs.java
@@ -64,7 +64,7 @@ public class CommandInReachSchemaDefs implements Command {
 		GlobalSettings gs
 		,Options options
 		) throws Exception {
-		
+
 		if( options.getArguments().size() > 1 ){
 			throw new Exception("Unexpected argument: "+options.getArguments().get(1));
 		}
@@ -89,7 +89,7 @@ public class CommandInReachSchemaDefs implements Command {
 		InReachSettings inReachSettings = InReachConfiguration.getInReachSettings();
 		for(InReachForm form : inReachSettings.getForms()){
 			JSONObject jsonDef = schemaDefinitionFromForm(form);
-			
+
 			// Pretty print
 			gs.getOutStream().println(jsonDef.toString(3));
 			gs.getOutStream().println();
@@ -98,14 +98,14 @@ public class CommandInReachSchemaDefs implements Command {
 
 	private JSONObject schemaDefinitionFromForm(InReachForm form) throws Exception {
 		JSONObject jsonDef = new JSONObject();
-		
+
 		jsonDef.put("group", "inReach");
 		jsonDef.put("id", form.getTitle());
 		jsonDef.put("label", "InReach "+form.getTitle());
-		
+
 		JSONArray attributes = new JSONArray();
 		jsonDef.put("attributes", attributes);
-		
+
 		// Title
 		{
 			JSONObject attribute = new JSONObject();
@@ -115,24 +115,24 @@ public class CommandInReachSchemaDefs implements Command {
 			attribute.put("type", "title");
 			attribute.put("includedInBrief", true);
 		}
-		
+
 		for(InReachFormField field : form.getFields()){
 			JSONObject attribute = new JSONObject();
 			attributes.put(attribute);
-			
+
 			String label = field.getName();
 			String id = escapeJsonAttribute( field.getName() );
-			
+
 			attribute.put("label", label);
 			attribute.put("id", id);
-			
+
 			InReachFormField.Type fieldType = field.getType();
 			if( InReachFormField.Type.PICKLIST == fieldType ){
 				attribute.put("type", "selection");
 
 				JSONArray options = new JSONArray();
 				attribute.put("options", options);
-				
+
 				for(String v : field.getValues()){
 					JSONObject option = new JSONObject();
 					options.put(option);
@@ -140,25 +140,25 @@ public class CommandInReachSchemaDefs implements Command {
 					option.put("label", v);
 					option.put("value", v);
 				}
-				
+
 			} else if( InReachFormField.Type.TEXT == fieldType ) {
 				attribute.put("type", "string");
 				attribute.put("textarea", true);
 
-			} else if( InReachFormField.Type.NUMBER == fieldType) {	
+			} else if( InReachFormField.Type.NUMBER == fieldType) {
 				attribute.put("type", "string");
 
 			} else {
 				throw new Exception("Unexpected field type: "+fieldType);
 			}
 		}
-		
+
 		return jsonDef;
 	}
 
 	private String escapeJsonAttribute(String fieldName) {
 		StringBuilder sb = new StringBuilder();
-		
+
 		for(char c : fieldName.toCharArray()){
 			if( c >= '0' &&  c <= '9' ){
 				sb.append(c);
@@ -172,7 +172,7 @@ public class CommandInReachSchemaDefs implements Command {
 				// skip
 			}
 		}
-		
+
 		return sb.toString();
 	}
 }

--- a/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/Options.java
+++ b/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/Options.java
@@ -40,6 +40,7 @@ public class Options {
 	static final public String OPTION_SCHEMA = "--schema";
 	static final public String OPTION_LAYER = "--layer";
 	static final public String OPTION_NAME = "--name";
+	static final public String OPTION_ADD_SCHEMA = "--add-schema";
 
 	static final public String OPTION_SET_LOGGER = "--set-logger";
 	static final public String OPTION_DEBUG = "--debug";
@@ -61,6 +62,7 @@ public class Options {
 	private Boolean overwriteDocs;
 	private Boolean all;
 	private Boolean test;
+	private Boolean addSchema;
 	private String atlasDir;
 	private String def;
 	private String group;
@@ -239,6 +241,8 @@ public class Options {
 
 					name = argumentStack.pop();
 
+				} else if (OPTION_ADD_SCHEMA.equals(arg)) {
+					addSchema = Boolean.TRUE;
 				} else {
 					throw new Exception("Unrecognized option: "+arg);
 				}
@@ -343,6 +347,10 @@ public class Options {
 
 	public Boolean getTest() {
 		return test;
+	}
+	
+	public Boolean getAddSchema() {
+		return addSchema;
 	}
 
 	public String getAtlasDir() {


### PR DESCRIPTION
This fix helps to pass --add-schema flag to create schema for inReach forms with schemas-for-inreach command. 
If the flag is not passed it asks the user if they want to create a schema or not. create schema if users answers "yes", else just print out the JSON definition.