### PR TITLE
Document editing before save dispatcher event

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchEdit.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchEdit.js
@@ -1528,6 +1528,14 @@ var CouchDocumentEditor = $n2.Class({
 
 	_save: function(){
 		var _this = this;
+
+		const msg = {
+			type: 'editBeforeSave'
+			, doc: this.editedDocument
+			, shouldContinue: true
+		}
+		this.dispatchService.synchronousCall(DH, msg);
+		if (!msg?.shouldContinue) return false;
 		
 		if (window.cordova) {
 			// alert if media documents are missing the attachment
@@ -1908,7 +1916,7 @@ var CouchDocumentEditor = $n2.Class({
 			return;
 		};
 	
-		this._save();
+		return this._save();
 	},
 
 	_discardEditor: function(opts_) {
@@ -2473,8 +2481,8 @@ var CouchEditService = $n2.Class({
 	
 	saveDocumentForm: function(opts){
 		if( null != this.currentEditor ) {
-			this.currentEditor.performSave(opts);
-			this.currentEditor = null;
+			const res = this.currentEditor.performSave(opts);
+			if (res) this.currentEditor = null;
 		};
 	},
 


### PR DESCRIPTION
Add synchronous dispatcher event when Save is clicked in the form view of a document. Provides the document and a flag if the rest of the code should continue or not.