### PR TITLE
Dispatch editCancel event early before viewing new document request starts

### DIFF
--- a/nunaliit2-couch-application/src/main/atlas_couchapp/_attachments/tools/js/select.js
+++ b/nunaliit2-couch-application/src/main/atlas_couchapp/_attachments/tools/js/select.js
@@ -19,6 +19,7 @@
 	var documentTransforms = [];
 	var allLists = [];
 	var selectedList = null;
+	var dispatchService = null;
 
 	// **********************************************************************
 	var DocumentList = $n2.Class({
@@ -3344,6 +3345,10 @@
 	
 	// -----------------------------------------------------------------
 	function viewDocument(docId){
+		dispatchService.send("select.js", {
+			type: "editCancel"
+		})
+
 		var $div = getDocumentDiv();
 		var $revs = getDocumentRevisionsDiv();
 		
@@ -3574,6 +3579,7 @@
 		config = opts_.config;
 		atlasDb = opts_.config.atlasDb;
 		atlasDesign = opts_.config.atlasDesign;
+		dispatchService = opts_.config.directory.dispatchService;
 		serverDesign = opts_.config.serverDesign;
 		siteDesign = opts_.config.siteDesign;
 		schemaRepository = opts_.config.directory.schemaRepository;


### PR DESCRIPTION
closes #852   
  
Raises a new issue - Editing a document in the document modification view by modifying a field (making input dirty) and then attempting to click on another document to view will potentially first open the same document again - requiring a second click to be able to view the proper document 