### PR TITLE
Add support for map canvas maker symbol for OL2 and OL6

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.styleRule.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.styleRule.js
@@ -695,11 +695,18 @@ function loadRuleFromObject(ruleObj){
 		condition = $n2.styleRuleParser.parse(ruleObj.condition);
 	};
 	
+	var normalStyle = ruleObj.normal ? ruleObj.normal : {};
+	if (ruleObj.marker && ruleObj.marker.icon) {
+		normalStyle.externalGraphic = ruleObj.marker.icon;
+		normalStyle.graphicWidth = ruleObj.marker.width || 16;
+		normalStyle.graphicHeight = ruleObj.marker.height || 16;
+	}
+	
 	var rule = new StyleRule({
 		condition: condition
 		,label: ruleObj.label
 		,source: ruleObj.condition
-		,normal: ruleObj.normal ? ruleObj.normal : {}
+		,normal: normalStyle
 		,selected: ruleObj.selected ? ruleObj.selected : {}
 		,found: ruleObj.found ? ruleObj.found : {}
 		,hovered: ruleObj.hovered ? ruleObj.hovered : {}

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.styleRule.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.styleRule.js
@@ -701,8 +701,8 @@ function loadRuleFromObject(ruleObj){
         var parsed = $n2.extend({}, rule);
 
         // If icon is provided, set it as externalGraphic
-        if (rule.icon) {
-            parsed.externalGraphic = rule.icon;
+        if (rule.iconSrc) {
+            parsed.externalGraphic = rule.iconSrc;
             parsed.graphicWidth = rule.width || 24;
             parsed.graphicHeight = rule.height || 24;
         }

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.styleRule.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.styleRule.js
@@ -695,22 +695,30 @@ function loadRuleFromObject(ruleObj){
 		condition = $n2.styleRuleParser.parse(ruleObj.condition);
 	};
 	
-	var normalStyle = ruleObj.normal ? ruleObj.normal : {};
-	if (ruleObj.marker && ruleObj.marker.icon) {
-		normalStyle.externalGraphic = ruleObj.marker.icon;
-		normalStyle.graphicWidth = ruleObj.marker.width || 16;
-		normalStyle.graphicHeight = ruleObj.marker.height || 16;
-	}
+	function parseSymbolizer(rule) {
+        if (!rule) return {};
+
+        var parsed = $n2.extend({}, rule);
+
+        // If icon is provided, set it as externalGraphic
+        if (rule.icon) {
+            parsed.externalGraphic = rule.icon;
+            parsed.graphicWidth = rule.width || 24;
+            parsed.graphicHeight = rule.height || 24;
+        }
+
+        return parsed;
+    }
 	
 	var rule = new StyleRule({
-		condition: condition
-		,label: ruleObj.label
-		,source: ruleObj.condition
-		,normal: normalStyle
-		,selected: ruleObj.selected ? ruleObj.selected : {}
-		,found: ruleObj.found ? ruleObj.found : {}
-		,hovered: ruleObj.hovered ? ruleObj.hovered : {}
-	});
+        condition: condition,
+        label: ruleObj.label,
+        source: ruleObj.condition,
+        normal: parseSymbolizer(ruleObj.normal),
+        selected: parseSymbolizer(ruleObj.selected),
+        found: parseSymbolizer(ruleObj.found),
+        hovered: parseSymbolizer(ruleObj.hovered),
+    });
 	
 	return rule;
 };


### PR DESCRIPTION
This PR it to add support for icons for OL2 and OL6 for normal, selected, hovered and found state.

### Usage
**OL2**
Example:
```json
{
	"condition": "some condition",
	"label": "Label",
	"normal": {
		"iconSrc": "img/marker/globe.svg",
		"width": 24,
		"height": 24
	},
	"hovered": {
		"iconSrc": "img/marker/citadel.png",
		"width": 24,
		"height": 24
	},
	"selected": {
		"iconSrc": "img/marker/tower.png",
		"width": 24,
		"height": 24
	},
	"found": {
		"iconSrc": "img/marker/tower.png",
		"width": 24,
		"height": 24
	}
}
```

**OL6**
Example:
```json
{
	"condition": "true",
	"normal": {
		"iconSrc": "img/marker/citadel.png",
		"scale": [0.05, 0.05],
		"iconColor": "#BADA55"
	},
	"selected": {
		"iconSrc": "img/marker/tower-icon.svg",
		"scale": [0.1, 0.1],
		"iconColor": "#BADA55"
	},
	"hovered": {
		"iconSrc": "img/marker/tower.png",
		"scale": [0.05, 0.05],
		"iconColor": ""
	},
	"found": {
		"iconSrc": "img/marker/tower-icon.svg",
		"scale": [1, 1],
		"iconColor": ""
	}
}
```