### PR TITLE
Ol canvas reprojection

### DIFF
--- a/nunaliit2-js/src/main/nunaliit-es6/package-lock.json
+++ b/nunaliit2-js/src/main/nunaliit-es6/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "imports-loader": "^0.8.0",
         "json-loader": "^0.5.7",
-        "ol": "^6.7.0",
-        "ol-ext": "^3.2.6",
-        "ol-layerswitcher": "^3.8.3"
+        "ol": "^10.5.0",
+        "ol-ext": "^4.0.31",
+        "ol-layerswitcher": "^4.1.2"
       },
       "devDependencies": {
         "babel-core": "^6.26.3",
@@ -230,45 +230,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@mapbox/mapbox-gl-style-spec": {
-      "version": "13.21.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
-      "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.5",
-        "rw": "^1.3.3",
-        "sort-object": "^0.3.2"
-      },
-      "bin": {
-        "gl-style-composite": "bin/gl-style-composite",
-        "gl-style-format": "bin/gl-style-format",
-        "gl-style-migrate": "bin/gl-style-migrate",
-        "gl-style-validate": "bin/gl-style-validate"
-      }
-    },
-    "node_modules/@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
-    },
-    "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -305,14 +266,9 @@
       }
     },
     "node_modules/@petamoriken/float16": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
-      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
-      "deprecated": "critical bug fixed in v3.1.1",
-      "dependencies": {
-        "lodash": ">=4.17.5 <5.0.0",
-        "lodash-es": ">=4.17.5 <5.0.0"
-      }
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -441,6 +397,11 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
+    },
+    "node_modules/@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ=="
     },
     "node_modules/@types/retry": {
       "version": "0.12.1",
@@ -2501,6 +2462,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3027,11 +2989,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
-    },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
@@ -3092,7 +3049,8 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3166,11 +3124,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/csscolorparser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -3520,6 +3473,11 @@
         "is-plain-object": "^2.0.1",
         "object.defaults": "^1.1.0"
       }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
+      "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3932,15 +3890,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/espree": {
       "version": "9.3.1",
@@ -5068,39 +5017,22 @@
       "dev": true
     },
     "node_modules/geotiff": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.5.tgz",
-      "integrity": "sha512-PK1dA22HJrgSjpDKXCcmihi/3NOTvAwZRV93pDCAI/bu3JYhgealCPMmzRQ6zJ/osfrrd9U4WXl3IHrwA9hqfg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
       "dependencies": {
-        "@petamoriken/float16": "^1.0.7",
-        "content-type-parser": "^1.0.2",
+        "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
-        "lru-cache": "^6.0.0",
-        "pako": "^1.0.11",
+        "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
-        "threads": "^1.3.1",
-        "txml": "^3.1.2"
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
       },
       "engines": {
-        "browsers": "defaults",
         "node": ">=10.19"
       }
-    },
-    "node_modules/geotiff/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/geotiff/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/get-caller-file": {
       "version": "1.0.3",
@@ -6305,11 +6237,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -6394,7 +6321,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -6757,17 +6685,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-observable": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
-      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -6967,7 +6884,8 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -7142,11 +7060,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "node_modules/json-stringify-pretty-compact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
-      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
     },
     "node_modules/json5": {
       "version": "1.0.2",
@@ -7411,12 +7324,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -7480,11 +7389,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/mapbox-to-css-font": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
-      "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg=="
     },
     "node_modules/markdown-it": {
       "version": "12.3.2",
@@ -8435,11 +8339,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/observable-fns": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
-      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
-    },
     "node_modules/obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -8447,14 +8346,15 @@
       "dev": true
     },
     "node_modules/ol": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.7.0.tgz",
-      "integrity": "sha512-MEdU3MQCT1KUb0Tt2/9oemUze9qi/O+1IsXCWivSaEIzf9sIbYe2UcKwJzjmmrQpe87em+T3gk9SICSF/p3z7Q==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.5.0.tgz",
+      "integrity": "sha512-nHFx8gkGmvYImsa7iKkwUnZidd5gn1XbMZd9GNOorvm9orjW9gQvT3Naw/MjIasVJ3cB9EJUdCGR2EFAulMHsQ==",
       "dependencies": {
-        "geotiff": "^1.0.5",
-        "ol-mapbox-style": "^6.4.1",
-        "pbf": "3.2.1",
-        "rbush": "^3.0.1"
+        "@types/rbush": "4.0.0",
+        "earcut": "^3.0.0",
+        "geotiff": "^2.1.3",
+        "pbf": "4.0.1",
+        "rbush": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8462,32 +8362,19 @@
       }
     },
     "node_modules/ol-ext": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-3.2.6.tgz",
-      "integrity": "sha512-D4xDT/DtHn8ykj+Fk5wMCfs+BUrwhDdVZBJXWP+ioH246y1zyAmCNDy6+eL+EC7+jY5gJrB1S9yiNP3vzaRTjw==",
+      "version": "4.0.31",
+      "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-4.0.31.tgz",
+      "integrity": "sha512-byh26JcXZggkLUY79+c29cxf2ovkkwz5niWJzOIN+dLPDJ+ogSn0y4Wl8fIS9O2JtQff5/cInHRImgZBvl+N1g==",
       "peerDependencies": {
         "ol": ">= 5.3.0"
       }
     },
     "node_modules/ol-layerswitcher": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/ol-layerswitcher/-/ol-layerswitcher-3.8.3.tgz",
-      "integrity": "sha512-UwUhalf/sGXjz3rvr0EjwsaUVlJAhyJCfcIPciKk1QdNbMKq/2ZXNKGafOjwP2eDxiqhkvnhpIrDGD8+gQ19Cg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ol-layerswitcher/-/ol-layerswitcher-4.1.2.tgz",
+      "integrity": "sha512-yF1iNqPKWr7AcsIWnr5He+T/J4X3qdce7qr8QUi/5Xyjo6uFjVvVijdAhMwiNfJrBNh9JhrXeDSl+1/cTT58KA==",
       "peerDependencies": {
         "ol": ">=5.0.0"
-      }
-    },
-    "node_modules/ol-mapbox-style": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.4.2.tgz",
-      "integrity": "sha512-iQyl5zBC1UiZIB7t4/7NpQruNS2Sk30jKecZuzyTFOksqRSrjVVkPaVmnUOrMAao0bWcOCrcb2zBTb+DQVMfAw==",
-      "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
-        "mapbox-to-css-font": "^2.4.0",
-        "webfont-matcher": "^1.1.0"
-      },
-      "peerDependencies": {
-        "ol": ">= 6.1.0 < 7"
       }
     },
     "node_modules/on-finished": {
@@ -8685,9 +8572,9 @@
       }
     },
     "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -8752,9 +8639,9 @@
       }
     },
     "node_modules/parse-headers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
-      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="
     },
     "node_modules/parse-json": {
       "version": "2.2.0",
@@ -8897,11 +8784,10 @@
       }
     },
     "node_modules/pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
       "dependencies": {
-        "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
       },
       "bin": {
@@ -9173,7 +9059,8 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "node_modules/proj4": {
       "version": "2.15.0",
@@ -9283,10 +9170,21 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
     },
     "node_modules/randomatic": {
       "version": "3.1.1",
@@ -9360,11 +9258,11 @@
       "dev": true
     },
     "node_modules/rbush": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
       "dependencies": {
-        "quickselect": "^2.0.0"
+        "quickselect": "^3.0.0"
       }
     },
     "node_modules/read-pkg": {
@@ -9398,6 +9296,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -9818,15 +9717,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
-    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -10468,34 +10363,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/sort-asc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-desc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-object": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "dependencies": {
-        "sort-asc": "^0.1.0",
-        "sort-desc": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10846,6 +10713,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11136,44 +11004,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "node_modules/threads": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
-      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
-      "dependencies": {
-        "callsites": "^3.1.0",
-        "debug": "^4.2.0",
-        "is-observable": "^2.1.0",
-        "observable-fns": "^0.6.1"
-      },
-      "funding": {
-        "url": "https://github.com/andywer/threads.js?sponsor=1"
-      },
-      "optionalDependencies": {
-        "tiny-worker": ">= 2"
-      }
-    },
-    "node_modules/threads/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/threads/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -11213,15 +11043,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tiny-worker": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
-      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
-      "optional": true,
-      "dependencies": {
-        "esm": "^3.2.25"
       }
     },
     "node_modules/to-absolute-glob": {
@@ -11338,23 +11159,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/txml": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-3.2.5.tgz",
-      "integrity": "sha512-AtN8AgJLiDanttIXJaQlxH8/R0NOCNwto8kcO7BaxdLgsN9b7itM9lnTD7c2O3TadP+hHB9j7ra5XGFRPNnk/g==",
-      "dependencies": {
-        "through2": "^3.0.1"
-      }
-    },
-    "node_modules/txml/node_modules/through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
       }
     },
     "node_modules/type": {
@@ -11628,7 +11432,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -11874,10 +11679,10 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "node_modules/webfont-matcher": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
-      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc="
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="
     },
     "node_modules/webpack": {
       "version": "5.94.0",
@@ -12598,6 +12403,11 @@
         }
       }
     },
+    "node_modules/xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA=="
+    },
     "node_modules/xmlcreate": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
@@ -12649,6 +12459,11 @@
         "camelcase": "^3.0.0",
         "object.assign": "^4.1.0"
       }
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
     }
   },
   "dependencies": {
@@ -12790,36 +12605,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
-      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
-    },
-    "@mapbox/mapbox-gl-style-spec": {
-      "version": "13.21.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
-      "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
-      "requires": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^2.0.0",
-        "minimist": "^1.2.5",
-        "rw": "^1.3.3",
-        "sort-object": "^0.3.2"
-      }
-    },
-    "@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
-    },
-    "@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -12847,13 +12632,9 @@
       }
     },
     "@petamoriken/float16": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
-      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
-      "requires": {
-        "lodash": ">=4.17.5 <5.0.0",
-        "lodash-es": ">=4.17.5 <5.0.0"
-      }
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog=="
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -12982,6 +12763,11 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
+    },
+    "@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ=="
     },
     "@types/retry": {
       "version": "0.12.1",
@@ -14776,7 +14562,8 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camelcase": {
       "version": "3.0.0",
@@ -15186,11 +14973,6 @@
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true
     },
-    "content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
-    },
     "convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
@@ -15242,7 +15024,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -15296,11 +15079,6 @@
           "dev": true
         }
       }
-    },
-    "csscolorparser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
     },
     "cssesc": {
       "version": "3.0.0",
@@ -15579,6 +15357,11 @@
         "is-plain-object": "^2.0.1",
         "object.defaults": "^1.1.0"
       }
+    },
+    "earcut": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
+      "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -15898,12 +15681,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
-    },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "optional": true
     },
     "espree": {
       "version": "9.3.1",
@@ -16794,33 +16571,18 @@
       "dev": true
     },
     "geotiff": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.5.tgz",
-      "integrity": "sha512-PK1dA22HJrgSjpDKXCcmihi/3NOTvAwZRV93pDCAI/bu3JYhgealCPMmzRQ6zJ/osfrrd9U4WXl3IHrwA9hqfg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
       "requires": {
-        "@petamoriken/float16": "^1.0.7",
-        "content-type-parser": "^1.0.2",
+        "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
-        "lru-cache": "^6.0.0",
-        "pako": "^1.0.11",
+        "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
-        "threads": "^1.3.1",
-        "txml": "^3.1.2"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
       }
     },
     "get-caller-file": {
@@ -17766,11 +17528,6 @@
       "dev": true,
       "requires": {}
     },
-    "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -17831,7 +17588,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -18088,11 +17846,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-observable": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
-      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw=="
-    },
     "is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -18226,7 +17979,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -18366,11 +18120,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "json-stringify-pretty-compact": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
-      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
     },
     "json5": {
       "version": "1.0.2",
@@ -18582,12 +18331,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -18639,11 +18384,6 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
-    },
-    "mapbox-to-css-font": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.0.tgz",
-      "integrity": "sha512-v674D0WtpxCXlA6E+sBlG1QJWdUkz/s9qAD91bJSXBGuBL5lL4tJXpoJEftecphCh2SVQCjWMS2vhylc3AIQTg=="
     },
     "markdown-it": {
       "version": "12.3.2",
@@ -19363,11 +19103,6 @@
         "make-iterator": "^1.0.0"
       }
     },
-    "observable-fns": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
-      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
-    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -19375,37 +19110,28 @@
       "dev": true
     },
     "ol": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.7.0.tgz",
-      "integrity": "sha512-MEdU3MQCT1KUb0Tt2/9oemUze9qi/O+1IsXCWivSaEIzf9sIbYe2UcKwJzjmmrQpe87em+T3gk9SICSF/p3z7Q==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.5.0.tgz",
+      "integrity": "sha512-nHFx8gkGmvYImsa7iKkwUnZidd5gn1XbMZd9GNOorvm9orjW9gQvT3Naw/MjIasVJ3cB9EJUdCGR2EFAulMHsQ==",
       "requires": {
-        "geotiff": "^1.0.5",
-        "ol-mapbox-style": "^6.4.1",
-        "pbf": "3.2.1",
-        "rbush": "^3.0.1"
+        "@types/rbush": "4.0.0",
+        "earcut": "^3.0.0",
+        "geotiff": "^2.1.3",
+        "pbf": "4.0.1",
+        "rbush": "^4.0.0"
       }
     },
     "ol-ext": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-3.2.6.tgz",
-      "integrity": "sha512-D4xDT/DtHn8ykj+Fk5wMCfs+BUrwhDdVZBJXWP+ioH246y1zyAmCNDy6+eL+EC7+jY5gJrB1S9yiNP3vzaRTjw==",
+      "version": "4.0.31",
+      "resolved": "https://registry.npmjs.org/ol-ext/-/ol-ext-4.0.31.tgz",
+      "integrity": "sha512-byh26JcXZggkLUY79+c29cxf2ovkkwz5niWJzOIN+dLPDJ+ogSn0y4Wl8fIS9O2JtQff5/cInHRImgZBvl+N1g==",
       "requires": {}
     },
     "ol-layerswitcher": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/ol-layerswitcher/-/ol-layerswitcher-3.8.3.tgz",
-      "integrity": "sha512-UwUhalf/sGXjz3rvr0EjwsaUVlJAhyJCfcIPciKk1QdNbMKq/2ZXNKGafOjwP2eDxiqhkvnhpIrDGD8+gQ19Cg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ol-layerswitcher/-/ol-layerswitcher-4.1.2.tgz",
+      "integrity": "sha512-yF1iNqPKWr7AcsIWnr5He+T/J4X3qdce7qr8QUi/5Xyjo6uFjVvVijdAhMwiNfJrBNh9JhrXeDSl+1/cTT58KA==",
       "requires": {}
-    },
-    "ol-mapbox-style": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.4.2.tgz",
-      "integrity": "sha512-iQyl5zBC1UiZIB7t4/7NpQruNS2Sk30jKecZuzyTFOksqRSrjVVkPaVmnUOrMAao0bWcOCrcb2zBTb+DQVMfAw==",
-      "requires": {
-        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
-        "mapbox-to-css-font": "^2.4.0",
-        "webfont-matcher": "^1.1.0"
-      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -19550,9 +19276,9 @@
       "dev": true
     },
     "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -19604,9 +19330,9 @@
       }
     },
     "parse-headers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
-      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="
     },
     "parse-json": {
       "version": "2.2.0",
@@ -19716,11 +19442,10 @@
       }
     },
     "pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
       "requires": {
-        "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
       }
     },
@@ -19903,7 +19628,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "proj4": {
       "version": "2.15.0",
@@ -19986,10 +19712,15 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ=="
+    },
     "quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g=="
     },
     "randomatic": {
       "version": "3.1.1",
@@ -20052,11 +19783,11 @@
       "dev": true
     },
     "rbush": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
       "requires": {
-        "quickselect": "^2.0.0"
+        "quickselect": "^3.0.0"
       }
     },
     "read-pkg": {
@@ -20084,6 +19815,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -20405,15 +20137,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -20943,25 +20671,6 @@
         }
       }
     },
-    "sort-asc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k="
-    },
-    "sort-desc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4="
-    },
-    "sort-object": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "requires": {
-        "sort-asc": "^0.1.0",
-        "sort-desc": "^0.1.1"
-      }
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -21252,6 +20961,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -21464,33 +21174,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "threads": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
-      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
-      "requires": {
-        "callsites": "^3.1.0",
-        "debug": "^4.2.0",
-        "is-observable": "^2.1.0",
-        "observable-fns": "^0.6.1",
-        "tiny-worker": ">= 2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -21528,15 +21211,6 @@
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
-    },
-    "tiny-worker": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
-      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
-      "optional": true,
-      "requires": {
-        "esm": "^3.2.25"
-      }
     },
     "to-absolute-glob": {
       "version": "2.0.2",
@@ -21625,25 +21299,6 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==",
       "dev": true
-    },
-    "txml": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-3.2.5.tgz",
-      "integrity": "sha512-AtN8AgJLiDanttIXJaQlxH8/R0NOCNwto8kcO7BaxdLgsN9b7itM9lnTD7c2O3TadP+hHB9j7ra5XGFRPNnk/g==",
-      "requires": {
-        "through2": "^3.0.1"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-          "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "2 || 3"
-          }
-        }
-      }
     },
     "type": {
       "version": "1.2.0",
@@ -21868,7 +21523,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -22076,10 +21732,10 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "webfont-matcher": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/webfont-matcher/-/webfont-matcher-1.1.0.tgz",
-      "integrity": "sha1-mM6VCXsp4x++czBT4Q5XFkLRxsc="
+    "web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="
     },
     "webpack": {
       "version": "5.94.0",
@@ -22561,6 +22217,11 @@
       "dev": true,
       "requires": {}
     },
+    "xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA=="
+    },
     "xmlcreate": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
@@ -22609,6 +22270,11 @@
         "camelcase": "^3.0.0",
         "object.assign": "^4.1.0"
       }
+    },
+    "zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
     }
   }
 }

--- a/nunaliit2-js/src/main/nunaliit-es6/package-lock.json
+++ b/nunaliit2-js/src/main/nunaliit-es6/package-lock.json
@@ -39,6 +39,7 @@
         "minimist": "^1.2.6",
         "npm-watch": "^0.11.0",
         "plugin-error": "^1.0.1",
+        "proj4": "2.15.0",
         "script-loader": "^0.7.2",
         "shx": "^0.3.2",
         "style-loader": "^3.3.1",
@@ -7631,6 +7632,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+      "dev": true
+    },
     "node_modules/micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -9167,6 +9174,16 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/proj4": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.15.0.tgz",
+      "integrity": "sha512-LqCNEcPdI03BrCHxPLj29vsd5afsm+0sV1H/O3nTDKrv8/LA01ea1z4QADDMjUqxSXWnrmmQDjqFm1J/uZ5RLw==",
+      "dev": true,
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.4.0"
+      }
     },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
@@ -12503,6 +12520,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "dev": true
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.4.0.tgz",
+      "integrity": "sha512-qpwO7Ihds/YYDTi1aADFTI1Sm9YC/tTe3SHD24EeIlZxy7Ik6a1b4HOz7jAi0xdUAw487duqpo8OGu+Tf4nwlQ==",
       "dev": true
     },
     "node_modules/word-wrap": {
@@ -18734,6 +18757,12 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
+    "mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+      "dev": true
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -19875,6 +19904,16 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "proj4": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.15.0.tgz",
+      "integrity": "sha512-LqCNEcPdI03BrCHxPLj29vsd5afsm+0sV1H/O3nTDKrv8/LA01ea1z4QADDMjUqxSXWnrmmQDjqFm1J/uZ5RLw==",
+      "dev": true,
+      "requires": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.4.0"
+      }
     },
     "protocol-buffers-schema": {
       "version": "3.6.0",
@@ -22468,6 +22507,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "dev": true
+    },
+    "wkt-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.4.0.tgz",
+      "integrity": "sha512-qpwO7Ihds/YYDTi1aADFTI1Sm9YC/tTe3SHD24EeIlZxy7Ik6a1b4HOz7jAi0xdUAw487duqpo8OGu+Tf4nwlQ==",
       "dev": true
     },
     "word-wrap": {

--- a/nunaliit2-js/src/main/nunaliit-es6/package-lock.json
+++ b/nunaliit2-js/src/main/nunaliit-es6/package-lock.json
@@ -13,7 +13,8 @@
         "json-loader": "^0.5.7",
         "ol": "^10.5.0",
         "ol-ext": "^4.0.31",
-        "ol-layerswitcher": "^4.1.2"
+        "ol-layerswitcher": "^4.1.2",
+        "proj4": "2.15.0"
       },
       "devDependencies": {
         "babel-core": "^6.26.3",
@@ -39,7 +40,6 @@
         "minimist": "^1.2.6",
         "npm-watch": "^0.11.0",
         "plugin-error": "^1.0.1",
-        "proj4": "2.15.0",
         "script-loader": "^0.7.2",
         "shx": "^0.3.2",
         "style-loader": "^3.3.1",
@@ -7539,8 +7539,7 @@
     "node_modules/mgrs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
-      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
-      "dev": true
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA=="
     },
     "node_modules/micromatch": {
       "version": "3.1.10",
@@ -9066,7 +9065,6 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.15.0.tgz",
       "integrity": "sha512-LqCNEcPdI03BrCHxPLj29vsd5afsm+0sV1H/O3nTDKrv8/LA01ea1z4QADDMjUqxSXWnrmmQDjqFm1J/uZ5RLw==",
-      "dev": true,
       "dependencies": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.4.0"
@@ -12330,8 +12328,7 @@
     "node_modules/wkt-parser": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.4.0.tgz",
-      "integrity": "sha512-qpwO7Ihds/YYDTi1aADFTI1Sm9YC/tTe3SHD24EeIlZxy7Ik6a1b4HOz7jAi0xdUAw487duqpo8OGu+Tf4nwlQ==",
-      "dev": true
+      "integrity": "sha512-qpwO7Ihds/YYDTi1aADFTI1Sm9YC/tTe3SHD24EeIlZxy7Ik6a1b4HOz7jAi0xdUAw487duqpo8OGu+Tf4nwlQ=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.4",
@@ -18500,8 +18497,7 @@
     "mgrs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
-      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
-      "dev": true
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA=="
     },
     "micromatch": {
       "version": "3.1.10",
@@ -19635,7 +19631,6 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.15.0.tgz",
       "integrity": "sha512-LqCNEcPdI03BrCHxPLj29vsd5afsm+0sV1H/O3nTDKrv8/LA01ea1z4QADDMjUqxSXWnrmmQDjqFm1J/uZ5RLw==",
-      "dev": true,
       "requires": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.4.0"
@@ -22168,8 +22163,7 @@
     "wkt-parser": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.4.0.tgz",
-      "integrity": "sha512-qpwO7Ihds/YYDTi1aADFTI1Sm9YC/tTe3SHD24EeIlZxy7Ik6a1b4HOz7jAi0xdUAw487duqpo8OGu+Tf4nwlQ==",
-      "dev": true
+      "integrity": "sha512-qpwO7Ihds/YYDTi1aADFTI1Sm9YC/tTe3SHD24EeIlZxy7Ik6a1b4HOz7jAi0xdUAw487duqpo8OGu+Tf4nwlQ=="
     },
     "word-wrap": {
       "version": "1.2.4",

--- a/nunaliit2-js/src/main/nunaliit-es6/package.json
+++ b/nunaliit2-js/src/main/nunaliit-es6/package.json
@@ -8,7 +8,8 @@
     "json-loader": "^0.5.7",
     "ol": "^10.5.0",
     "ol-ext": "^4.0.31",
-    "ol-layerswitcher": "^4.1.2"
+    "ol-layerswitcher": "^4.1.2",
+    "proj4": "2.15.0"
   },
   "devDependencies": {
     "jsdoc": "^3.6.10",
@@ -34,7 +35,6 @@
     "minimist": "^1.2.6",
     "npm-watch": "^0.11.0",
     "plugin-error": "^1.0.1",
-    "proj4": "2.15.0",
     "script-loader": "^0.7.2",
     "shx": "^0.3.2",
     "style-loader": "^3.3.1",

--- a/nunaliit2-js/src/main/nunaliit-es6/package.json
+++ b/nunaliit2-js/src/main/nunaliit-es6/package.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "imports-loader": "^0.8.0",
     "json-loader": "^0.5.7",
-    "ol": "^6.7.0",
-    "ol-ext": "^3.2.6",
-    "ol-layerswitcher": "^3.8.3"
+    "ol": "^10.5.0",
+    "ol-ext": "^4.0.31",
+    "ol-layerswitcher": "^4.1.2"
   },
   "devDependencies": {
     "jsdoc": "^3.6.10",

--- a/nunaliit2-js/src/main/nunaliit-es6/package.json
+++ b/nunaliit2-js/src/main/nunaliit-es6/package.json
@@ -34,6 +34,7 @@
     "minimist": "^1.2.6",
     "npm-watch": "^0.11.0",
     "plugin-error": "^1.0.1",
+    "proj4": "2.15.0",
     "script-loader": "^0.7.2",
     "shx": "^0.3.2",
     "style-loader": "^3.3.1",

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/EditBar.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/EditBar.js
@@ -3,485 +3,205 @@
 /**
 * @module n2es6/n2mapModule/EditBar
 */
-import ol_ext_inherits from 'ol-ext/util/ext'
-import {shiftKeyOnly as ol_events_condition_shiftKeyOnly} from 'ol/events/condition'
-import {click as ol_events_condition_click} from 'ol/events/condition'
-import ol_interaction_Draw from 'ol/interaction/Draw'
-import ol_geom_LineString from 'ol/geom/LineString'
-import ol_geom_Polygon from 'ol/geom/Polygon'
-import ol_interaction_Select from 'ol/interaction/Select'
-import {default as N2Select} from './N2Select.js';
 
-import ol_control_Bar from 'ol-ext/control/Bar'
-import ol_control_Button from 'ol-ext/control/Button'
-import ol_control_Toggle from 'ol-ext/control/Toggle'
-import ol_control_TextButton from 'ol-ext/control/TextButton'
-import ol_interaction_Delete from 'ol-ext/interaction/Delete'
-import ol_ext_element from 'ol-ext/util/element'
-import ol_interaction_Offset from 'ol-ext/interaction/Offset'
-import ol_interaction_Split from 'ol-ext/interaction/Split'
-import ol_interaction_Transform from 'ol-ext/interaction/Transform'
-import ol_interaction_ModifyFeature from './ModifyFeature'
-import ol_interaction_DrawRegular from 'ol-ext/interaction/DrawRegular'
-import ol_interaction_DrawHole from 'ol-ext/interaction/DrawHole'
+import ol_control_Bar from 'ol-ext/control/Bar.js'
+import ol_control_Button from 'ol-ext/control/Button.js'
+import ol_control_Editbar from 'ol-ext/control/EditBar.js'
 
-/** Control bar for editing in a layer
- * @constructor
- * @extends {ol_control_Bar}
- * @fires info
- * @param {Object=} options Control options.
- *	@param {String} options.className class of the control
- *	@param {String} options.target Specify a target if you want the control to be rendered outside of the map's viewport.
- *	@param {boolean} options.edition false to remove the edition tools, default true
- *	@param {Object} options.interactions List of interactions to add to the bar 
- *	  ie. Select, Delete, Info, DrawPoint, DrawLine, DrawPolygon
- *	  Each interaction can be an interaction or true (to get the default one) or false to remove it from bar
- *	@param {ol.source.Vector} options.source Source for the drawn features. 
- */
-var ol_control_EditBar = function(options) {
-  options = options || {};
-  options.interactions = options.interactions || {};
+import { shiftKeyOnly as ol_events_condition_shiftKeyOnly } from 'ol/events/condition.js'
+import { click as ol_events_condition_click } from 'ol/events/condition.js'
+import ol_interaction_Select from 'ol/interaction/Select.js'
 
-  // New bar
-	ol_control_Bar.call(this, {
-	className: (options.className ? options.className+' ': '') + 'ol-editbar',
-	toggleOne: true,
-		target: options.target
-  });
+import { default as N2Select } from './N2Select.js';
 
-  this._source = options.source;
-  // Add buttons / interaction
-  this._interactions = {};
-  this._setSelectInteraction(options);
-  if (options.edition!==false) this._setEditInteraction(options);
-  this.modifyWithSelect = true;
-  this._setModifyInteraction(options);
-};
-ol_ext_inherits(ol_control_EditBar, ol_control_Bar);
+import ol_interaction_ModifyFeature from 'ol-ext/interaction/ModifyFeature.js'
+import ol_control_Toggle from 'ol-ext/control/Toggle.js'
+import ol_interaction_Delete from 'ol-ext/interaction/Delete.js'
+import ol_interaction_Offset from 'ol-ext/interaction/Offset.js'
+import ol_interaction_Transform from 'ol-ext/interaction/Transform.js'
+import ol_interaction_Split from 'ol-ext/interaction/Split.js'
 
-/**
- * Set the map instance the control is associated with
- * and add its controls associated to this map.
- * @param {_ol_Map_} map The map instance.
- */
-ol_control_EditBar.prototype.setMap = function (map) {
-  if (this.getMap()) {
-	if (this._interactions.Delete) this.getMap().removeInteraction(this._interactions.Delete);
-	if (this._interactions.ModifySelect) this.getMap().removeInteraction(this._interactions.ModifySelect);
-  }
-  
-  ol_control_Bar.prototype.setMap.call(this, map);
+class EditBar extends ol_control_Editbar {
+	constructor(options) {
+		super(options)
+		this.modifyWithSelect = true
+	}
 
-  if (this.getMap()) {
-	if (this._interactions.Delete) this.getMap().addInteraction(this._interactions.Delete);
-	if (this._interactions.ModifySelect) this.getMap().addInteraction(this._interactions.ModifySelect);
-  }
-};
+	activateModify() {
+		this._interactions['ModifySelect'].setActive(true);
+	}
 
-/** Activate interaction modify 
- * @param {string} name 
- */
-ol_control_EditBar.prototype.activateModify = function () {
-	this._interactions['ModifySelect'].setActive(true);
-};
+	deactivateModify() {
+		this._interactions['ModifySelect'].setActive(false);
+	}
 
-/** Deactivate interaction modify
- */
-ol_control_EditBar.prototype.deactivateModify = function () {
-	this._interactions['ModifySelect'].setActive(false);
-};
+	setModifyWithSelect(isActive) {
+		this.modifyWithSelect = isActive || false
+	}
 
-/** Get an interaction associated with the bar
- * @param {string} name 
- */
-ol_control_EditBar.prototype.getInteraction = function (name) {
-	return this._interactions[name];
-};
+	// override
+	_setSelectInteraction(options) {
+		var self = this
 
-/** Get the option title */
-ol_control_EditBar.prototype._getTitle = function (option) {
-	return (option && option.title) ? option.title : option;
-};
+		// Sub bar
+		var sbar = new ol_control_Bar()
+		var selectCtrl
 
-/** Add selection tool:
- * 1. a toggle control with a select interaction
- * 2. an option bar to delete / get information on the selected feature
- * @private
- */
-ol_control_EditBar.prototype._setSelectInteraction = function (options) {
-	var self = this;
-
-	// Sub bar
-	var sbar = new ol_control_Bar();
-	var selectCtrl;
-
-	// Delete button
-	if (options.interactions.Delete !== false) {
-		if (options.interactions.Delete instanceof ol_interaction_Delete) {
-			this._interactions.Delete = options.interactions.Delete; 
-		} else {
-			this._interactions.Delete = new ol_interaction_Delete();
-		}
-
-		var del = this._interactions.Delete;
-		del.setActive(false);
-		if (this.getMap()) this.getMap().addInteraction(del);
-		sbar.addControl (new ol_control_Button({
-			className: 'ol-delete',
-			title: this._getTitle(options.interactions.Delete) || "Delete",
-			handleClick: function(e) {
-				// Delete selection
-				del.delete(selectCtrl.getInteraction().getFeatures());
-				console.log('del');
-				var evt = {
-					type: 'select',
-					selected: [],
-					deselected: selectCtrl.getInteraction().getFeatures().getArray().slice(),
-					mapBrowserEvent: e.mapBrowserEvent
-				};
-				selectCtrl.getInteraction().getFeatures().clear();
-				selectCtrl.getInteraction().dispatchEvent(evt);
+		// Delete button
+		if (options.interactions.Delete !== false) {
+			if (options.interactions.Delete instanceof ol_interaction_Delete) {
+				this._interactions.Delete = options.interactions.Delete
+			} else {
+				this._interactions.Delete = new ol_interaction_Delete()
 			}
-		}));
-	}
-
-	// Info button
-	if (options.interactions.Info !== false) {
-		sbar.addControl (new ol_control_Button({
-			className: 'ol-info',
-			title: this._getTitle(options.interactions.Info) || "Show informations",
-			handleClick: function() {
-				self.dispatchEvent({ 
-					type: 'info', 
-					features: selectCtrl.getInteraction().getFeatures() 
-				});
-			}
-		}));
-	}
-
-	// Select button
-	if (options.interactions.Select !== false) {
-		if (options.interactions.Select instanceof ol_interaction_Select
-			|| options.interactions.Select instanceof N2Select) {
-			this._interactions.Select = options.interactions.Select
-		} else {
-			this._interactions.Select = new ol_interaction_Select({
-				condition: ol_events_condition_click
-			});
-		}
-
-		var sel = this._interactions.Select;
-		selectCtrl = new ol_control_Toggle({
-			className: 'ol-selection',
-			title: this._getTitle(options.interactions.Select) || "Select",
-			interaction: sel,
-			bar: sbar.getControls().length ? sbar : undefined,
-			autoActivate:true,
-			active:true
-		});
-
-		this.addControl(selectCtrl);
-		sel.on('change:active', function() {
-			sel.getFeatures().clear();
-		});
-	}
-};
-
-
-/** Add editing tools
- * @private
- */ 
-ol_control_EditBar.prototype._setEditInteraction = function (options) {
-	if (options.interactions.DrawPoint !== false) {
-		if (options.interactions.DrawPoint instanceof ol_interaction_Draw) {
-			this._interactions.DrawPoint = options.interactions.DrawPoint;
-		} else {
-			this._interactions.DrawPoint = new ol_interaction_Draw({
-				type: 'Point',
-				source: this._source
-			});
-		}
-
-		var pedit = new ol_control_Toggle({
-			className: 'ol-drawpoint',
-			title: this._getTitle(options.interactions.DrawPoint) || 'Point',
-			interaction: this._interactions.DrawPoint
-		});
-		this.addControl ( pedit );
-	}
-
-	if (options.interactions.DrawLine !== false) {
-		if (options.interactions.DrawLine instanceof ol_interaction_Draw) {
-			this._interactions.DrawLine = options.interactions.DrawLine
-		} else {
-			this._interactions.DrawLine = new ol_interaction_Draw ({
-				type: 'LineString',
-				source: this._source,
-				// Count inserted points
-				geometryFunction: function(coordinates, geometry) {
-					if (geometry) {
-						geometry.setCoordinates(coordinates);
-					} else {
-						geometry = new ol_geom_LineString(coordinates);
+			var del = this._interactions.Delete
+			del.setActive(false)
+			if (this.getMap())
+				this.getMap().addInteraction(del)
+			sbar.addControl(new ol_control_Button({
+				className: 'ol-delete',
+				title: this._getTitle(options.interactions.Delete) || "Delete",
+				name: 'Delete',
+				handleClick: function (e) {
+					// Delete selection
+					del.delete(selectCtrl.getInteraction().getFeatures())
+					var evt = {
+						type: 'select',
+						selected: [],
+						deselected: selectCtrl.getInteraction().getFeatures().getArray().slice(),
+						mapBrowserEvent: e.mapBrowserEvent
 					}
-					this.nbpts = geometry.getCoordinates().length;
-					return geometry;
+					selectCtrl.getInteraction().getFeatures().clear()
+					selectCtrl.getInteraction().dispatchEvent(evt)
 				}
-			});
+			}))
 		}
 
-		var ledit = new ol_control_Toggle({
-			className: 'ol-drawline',
-			title: this._getTitle(options.interactions.DrawLine) || 'LineString',
-			interaction: this._interactions.DrawLine,
-			// Options bar associated with the control
-			bar: new ol_control_Bar ({
-				controls:[ 
-					new ol_control_TextButton({
-						html: this._getTitle(options.interactions.UndoDraw) || 'undo',
-						title: this._getTitle(options.interactions.UndoDraw) || "delete last point",
-						handleClick: function() {
-							if (ledit.getInteraction().nbpts>1) {
-								ledit.getInteraction().removeLastPoint();
-							}
-						}
-					}),
-
-					new ol_control_TextButton ({
-						html: this._getTitle(options.interactions.FinishDraw) || 'finish',
-						title: this._getTitle(options.interactions.FinishDraw) || "finish",
-						handleClick: function() {
-							// Prevent null objects on finishDrawing
-							if (ledit.getInteraction().nbpts>2) ledit.getInteraction().finishDrawing();
-						}
+		// Info button
+		if (options.interactions.Info !== false) {
+			sbar.addControl(new ol_control_Button({
+				className: 'ol-info',
+				name: 'Info',
+				title: this._getTitle(options.interactions.Info) || "Show informations",
+				handleClick: function () {
+					self.dispatchEvent({
+						type: 'info',
+						features: selectCtrl.getInteraction().getFeatures()
 					})
-				]
-			}) 
-		});
-
-		this.addControl ( ledit );
-	}
-
-	if (options.interactions.DrawPolygon !== false) {
-		if (options.interactions.DrawPolygon instanceof ol_interaction_Draw){
-			this._interactions.DrawPolygon = options.interactions.DrawPolygon
-		} else {
-			this._interactions.DrawPolygon = new ol_interaction_Draw ({
-				type: 'Polygon',
-				source: this._source,
-				// Count inserted points
-				geometryFunction: function(coordinates, geometry) {
-					this.nbpts = coordinates[0].length;
-					if (geometry){
-						geometry.setCoordinates([coordinates[0].concat([coordinates[0][0]])]);
-					} else {
-						geometry = new ol_geom_Polygon(coordinates);
-					}
-					return geometry;
 				}
-			});
+			}))
 		}
 
-		this._setDrawPolygon(
-			'ol-drawpolygon', 
-			this._interactions.DrawPolygon, 
-			this._getTitle(options.interactions.DrawPolygon) || 'Polygon', 
-			options
-		);
-	}
-
-	// Draw hole
-	if (options.interactions.DrawHole !== false) {
-		if (options.interactions.DrawHole instanceof ol_interaction_DrawHole){
-			this._interactions.DrawHole = options.interactions.DrawHole;
-		} else {
-			this._interactions.DrawHole = new ol_interaction_DrawHole ();
-		}
-		this._setDrawPolygon(
-			'ol-drawhole', 
-			this._interactions.DrawHole, 
-			this._getTitle(options.interactions.DrawHole) || 'Hole', 
-			options
-		);
-	}
-
-	// Draw regular
-	if (options.interactions.DrawRegular !== false) {
-		if (options.interactions.DrawRegular instanceof ol_interaction_DrawRegular) {
-			this._interactions.DrawRegular = options.interactions.DrawRegular
-		} else {
-			this._interactions.DrawRegular = new ol_interaction_DrawRegular ({
-				source: this._source,
-				sides: 4
-			});
-		}
-
-		var regular = this._interactions.DrawRegular;
-
-		var div = document.createElement('DIV');
-
-		var down = ol_ext_element.create('DIV', { parent: div });
-		ol_ext_element.addListener(down, ['click', 'touchstart'], function() {
-			var sides = regular.getSides() -1;
-			if (sides < 2){
-				sides = 2;
-			}
-			regular.setSides (sides);
-			text.textContent = sides>2 ? sides+' pts' : 'circle';
-		}.bind(this));
-
-		var text = ol_ext_element.create('TEXT', { html:'4 pts', parent: div });
-	
-		var up = ol_ext_element.create('DIV', { parent: div });
-		ol_ext_element.addListener(up, ['click', 'touchstart'], function() {
-			var sides = regular.getSides() +1;
-			if (sides<3) {
-				sides=3;
-			}
-			regular.setSides(sides);
-			text.textContent = sides+' pts';
-		}.bind(this));
-
-		var ctrl = new ol_control_Toggle({
-			className: 'ol-drawregular',
-			title: this._getTitle(options.interactions.DrawRegular) || 'Regular',
-			interaction: this._interactions.DrawRegular,
-			// Options bar associated with the control
-			bar: new ol_control_Bar ({
-				controls:[ 
-					new ol_control_TextButton({
-						html: div
-					})
-				]
-			}) 
-		});
-		this.addControl (ctrl);
-	}
-};
-
-/**
- * @private
- */
-ol_control_EditBar.prototype._setDrawPolygon = function (className, interaction, title, options) {
-	var fedit = new ol_control_Toggle ({
-		className: className,
-		title: title,
-		interaction: interaction,
-		// Options bar associated with the control
-		bar: new ol_control_Bar({
-			controls:[
-				new ol_control_TextButton ({
-					html: this._getTitle(options.interactions.UndoDraw) || 'undo',
-					title: this._getTitle(options.interactions.UndoDraw) || 'undo last point',
-					handleClick: function(){
-						if (fedit.getInteraction().nbpts>1){
-							fedit.getInteraction().removeLastPoint();
-						}
-					}
-				}),
-
-				new ol_control_TextButton({
-					html: this._getTitle(options.interactions.FinishDraw) || 'finish',
-					title: this._getTitle(options.interactions.FinishDraw) || 'finish',
-					handleClick: function() {
-						// Prevent null objects on finishDrawing
-						if (fedit.getInteraction().nbpts>3){
-							fedit.getInteraction().finishDrawing();
-						}
-					}
+		// Select button
+		if (options.interactions.Select !== false) {
+			// START CUSTOM
+			if (options.interactions.Select instanceof ol_interaction_Select
+				|| options.interactions.Select instanceof N2Select) {
+			// END CUSTOM
+				this._interactions.Select = options.interactions.Select
+			} else {
+				this._interactions.Select = new ol_interaction_Select({
+					condition: ol_events_condition_click
 				})
-			]
-		}) 
-	});
-	this.addControl (fedit);
-};
+			}
+			var sel = this._interactions.Select
+			selectCtrl = new ol_control_Toggle({
+				className: 'ol-selection',
+				name: 'Select',
+				title: this._getTitle(options.interactions.Select) || "Select",
+				interaction: sel,
+				bar: sbar.getControls().length ? sbar : undefined,
+				autoActivate: true,
+				active: true
+			})
 
-/** Add modify tools
- */ 
-ol_control_EditBar.prototype.setModifyWithSelect = function (active) {
-	this.modifyWithSelect = active || false;
+			this.addControl(selectCtrl)
+			sel.on('change:active', function () {
+				if (!sel.getActive())
+					sel.getFeatures().clear()
+			})
+		}
+	}
+
+	// override 
+	_setModifyInteraction(options) {
+		// Modify on selected features
+		if (options.interactions.ModifySelect !== false && options.interactions.Select !== false) {
+			if (options.interactions.ModifySelect instanceof ol_interaction_ModifyFeature) {
+				this._interactions.ModifySelect = options.interactions.ModifySelect
+			} else {
+				this._interactions.ModifySelect = new ol_interaction_ModifyFeature({
+					features: this.getInteraction('Select').getFeatures()
+				})
+			}
+			if (this.getMap())
+				this.getMap().addInteraction(this._interactions.ModifySelect)
+			// Activate with select
+			this._interactions.ModifySelect.setActive(this._interactions.Select.getActive())
+			this._interactions.Select.on('change:active', function () {
+				// START CUSTOM
+				if (!this._interactions.Select.getActive()) {
+					this._interactions.ModifySelect.setActive(this._interactions.Select.getActive());
+				} else if (this.modifyWithSelect) {
+					this._interactions.ModifySelect.setActive(this._interactions.Select.getActive());
+				}
+				// END CUSTOM
+			}.bind(this))
+		}
+
+		if (options.interactions.Transform !== false) {
+			if (options.interactions.Transform instanceof ol_interaction_Transform) {
+				this._interactions.Transform = options.interactions.Transform
+			} else {
+				this._interactions.Transform = new ol_interaction_Transform({
+					addCondition: ol_events_condition_shiftKeyOnly
+				})
+			}
+			var transform = new ol_control_Toggle({
+				html: '<i></i>',
+				className: 'ol-transform',
+				title: this._getTitle(options.interactions.Transform) || 'Transform',
+				name: 'Transform',
+				interaction: this._interactions.Transform
+			})
+			this.addControl(transform)
+		}
+
+		if (options.interactions.Split !== false) {
+			if (options.interactions.Split instanceof ol_interaction_Split) {
+				this._interactions.Split = options.interactions.Split
+			} else {
+				this._interactions.Split = new ol_interaction_Split({
+					sources: this._source
+				})
+			}
+			var split = new ol_control_Toggle({
+				className: 'ol-split',
+				title: this._getTitle(options.interactions.Split) || 'Split',
+				name: 'Split',
+				interaction: this._interactions.Split
+			})
+			this.addControl(split)
+		}
+
+		if (options.interactions.Offset !== false) {
+			if (options.interactions.Offset instanceof ol_interaction_Offset) {
+				this._interactions.Offset = options.interactions.Offset
+			} else {
+				this._interactions.Offset = new ol_interaction_Offset({
+					source: this._source
+				})
+			}
+			var offset = new ol_control_Toggle({
+				html: '<i></i>',
+				className: 'ol-offset',
+				title: this._getTitle(options.interactions.Offset) || 'Offset',
+				name: 'Offset',
+				interaction: this._interactions.Offset
+			})
+			this.addControl(offset)
+		}
+	}
 }
 
-/** Add modify tools
- * @private
- */ 
-ol_control_EditBar.prototype._setModifyInteraction = function (options) {
-	// Modify on selected features
-	if (options.interactions.ModifySelect !== false && options.interactions.Select !== false) {
-		if (options.interactions.ModifySelect instanceof ol_interaction_ModifyFeature) {
-			this._interactions.ModifySelect = options.interactions.ModifySelect;
-		} else {
-			this._interactions.ModifySelect = new ol_interaction_ModifyFeature({
-				features: this.getInteraction('Select').getFeatures()
-			});
-		}
-
-		if (this.getMap()){
-			this.getMap().addInteraction(this._interactions.ModifySelect);
-		}
-		// Activate with select
-		this._interactions.ModifySelect.setActive(false);
-		this._interactions.Select.on('change:active', function() {
-			if (!this._interactions.Select.getActive()){
-				this._interactions.ModifySelect.setActive(this._interactions.Select.getActive());
-			} else if (this.modifyWithSelect){
-				this._interactions.ModifySelect.setActive(this._interactions.Select.getActive());
-			}
-		}.bind(this));
-	}
-
-	if (options.interactions.Transform !== false) {
-		if (options.interactions.Transform instanceof ol_interaction_Transform) {
-			this._interactions.Transform = options.interactions.Transform;
-		} else {
-			this._interactions.Transform = new ol_interaction_Transform ({
-				addCondition: ol_events_condition_shiftKeyOnly
-			});
-		}
-
-		var transform = new ol_control_Toggle ({
-			html: '<i></i>',
-			className: 'ol-transform',
-			title: this._getTitle(options.interactions.Transform) || 'Transform',
-			interaction: this._interactions.Transform
-		});
-		this.addControl (transform);
-	}
-
-	if (options.interactions.Split !== false) {
-		if (options.interactions.Split instanceof ol_interaction_Split) {
-			this._interactions.Split = options.interactions.Split;
-		} else {
-			this._interactions.Split = new ol_interaction_Split ({
-				sources: this._source
-			});
-		}
-
-		var split = new ol_control_Toggle ({
-			className: 'ol-split',
-			title: this._getTitle(options.interactions.Split) || 'Split',
-			interaction: this._interactions.Split
-		});
-		this.addControl (split);
-	}
-
-	if (options.interactions.Offset !== false) {
-		if (options.interactions.Offset instanceof ol_interaction_Offset) {
-			this._interactions.Offset = options.interactions.Offset;
-		} else {
-			this._interactions.Offset = new ol_interaction_Offset ({
-				source: this._source
-			});
-		}
-
-		var offset = new ol_control_Toggle ({
-			html: '<i></i>',
-			className: 'ol-offset',
-			title: this._getTitle(options.interactions.Offset) || 'Offset',
-			interaction: this._interactions.Offset
-		});
-		this.addControl (offset);
-	}
-};
-
-export default ol_control_EditBar
+export default EditBar

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
@@ -131,6 +131,7 @@ class N2MapCanvas {
 		this.center = undefined;
 		this.resolution = undefined;
 		this.proj = undefined;
+		this.viewProjectionCode = 'EPSG:3857'
 		this.lastTime = null;
 		this.initialTime = null;
 		this.endIdx = 0;
@@ -220,7 +221,7 @@ class N2MapCanvas {
 					_this.dispatchService.send(DH, {
 						type: 'editCreateFromGeometry'
 						, geometry: feature.getGeometry()
-						, projection: new Projection({ code: 'EPSG:3857' })
+						, projection: new Projection({ code: _this.viewProjectionCode })
 						, _origin: _this
 					});
 				}
@@ -351,7 +352,7 @@ class N2MapCanvas {
 					source = new CouchDbSource({
 						sourceModelId: sourceModelId
 						, dispatchService: this.dispatchService
-						, projCode: 'EPSG:3857'
+						, projCode: _this.viewProjectionCode
 					});
 					this.sources.push(source);
 				}
@@ -364,7 +365,7 @@ class N2MapCanvas {
 					source = new N2ModelSource({
 						sourceModelId: sourceModelId
 						, dispatchService: this.dispatchService
-						, projCode: 'EPSG:3857'
+						, projCode: _this.viewProjectionCode
 						, onUpdateCallback: function (state) { }
 						, notifications: {
 							readStart: function () { }
@@ -609,8 +610,8 @@ class N2MapCanvas {
 		const _this = this;
 
 		const olView = new View({
-			center: transform([-75, 45.5], 'EPSG:4326', 'EPSG:3857'),
-			projection: 'EPSG:3857',
+			center: transform([-75, 45.5], 'EPSG:4326', this.viewProjectionCode),
+			projection: this.viewProjectionCode,
 			zoom: 6
 		});
 
@@ -643,7 +644,7 @@ class N2MapCanvas {
 			const bbox = this.coordinates.initialBounds;
 			const boundInProj = transformExtent(bbox,
 				new Projection({ code: 'EPSG:4326' }),
-				new Projection({ code: 'EPSG:3857' })
+				_this.n2View.getProjection()
 			);
 
 			customMap.once('postrender', function (evt) {
@@ -883,7 +884,7 @@ class N2MapCanvas {
 					type: 'editGeometryModified'
 					, docId: features[i].fid
 					, geom: geometry
-					, proj: new Projection({ code: 'EPSG:3857' })
+					, proj: _this.n2View.getProjection()
 					, _origin: _this
 				});
 			}
@@ -1399,13 +1400,13 @@ class N2MapCanvas {
 
 			if (m.projCode) {
 				const sourceProjCode = m.projCode;
-				const targetProjCode = 'EPSG:3857';
+				const targetProjCode = _this.viewProjectionCode;
 				if (targetProjCode !== sourceProjCode) {
 					const transformFn = getTransform(sourceProjCode, targetProjCode);
 					// Convert [0,0] and [0,1] to proj
 					targetCenter = transformFn([x, y]);
 				}
-				extent = this._computeFullBoundingBox(m.doc, 'EPSG:4326', 'EPSG:3857');
+				extent = this._computeFullBoundingBox(m.doc, 'EPSG:4326', _this.viewProjectionCode);
 			}
 
 			_this.n2View.cancelAnimations();

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
@@ -657,10 +657,7 @@ class N2MapCanvas {
 		//Config the initial bound on the map
 		if (this.coordinates && !this.coordinates.autoInitialBounds) {
 			const bbox = this.coordinates.initialBounds;
-			const boundInProj = transformExtent(bbox,
-				new Projection({ code: 'EPSG:4326' }),
-				_this.n2View.getProjection()
-			);
+			const boundInProj = this.defaultProjection === this.viewProjectionCode ? transformExtent(bbox, getProjection('EPSG:4326'), _this.n2View.getProjection()) : bbox
 			customMap.once('postrender', function (evt) {
 				const res = evt.frameState.viewState.resolution;
 				const proj = _this.n2View.getProjection();

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
@@ -661,7 +661,7 @@ class N2MapCanvas {
 		//Config the initial bound on the map
 		if (this.coordinates && !this.coordinates.autoInitialBounds) {
 			const bbox = this.coordinates.initialBounds;
-			const boundInProj = this.defaultProjection === this.viewProjectionCode ? transformExtent(bbox, getProjection('EPSG:4326'), _this.n2View.getProjection()) : bbox
+			const boundInProj = this.defaultProjection === this.viewProjectionCode ? transformExtent(bbox, 'EPSG:4326', _this.n2View.getProjection()) : bbox
 			customMap.once('postrender', function (evt) {
 				const res = evt.frameState.viewState.resolution;
 				const proj = _this.n2View.getProjection();

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
@@ -20,6 +20,8 @@ import { default as LayerGroup } from 'ol/layer/Group.js';
 import { default as View } from 'ol/View.js';
 import { default as N2DonutCluster } from '../ol5support/N2DonutCluster.js';
 
+import proj4 from 'proj4';
+import {register} from 'ol/proj/proj4.js';
 import { extend, isEmpty, getTopLeft, getWidth } from 'ol/extent.js';
 import { transform, getTransform, transformExtent, get as getProjection } from 'ol/proj.js';
 import { default as Projection } from 'ol/proj/Projection.js';
@@ -102,7 +104,13 @@ class N2MapCanvas {
 			, onSuccess: function () { }
 			, onError: function (err) { }
 		}, opts_);
-
+		
+		if(opts.projDefs) {
+			for(const def of opts.projDefs) {
+				proj4.defs(def.code, def.definition);
+			}
+			register(proj4);
+		}
 		const _this = this;
 		this.options = opts;
 		this._classname = 'N2MapCanvas';
@@ -131,7 +139,7 @@ class N2MapCanvas {
 		this.center = undefined;
 		this.resolution = undefined;
 		this.proj = undefined;
-		this.viewProjectionCode = 'EPSG:3857'
+		this.viewProjectionCode = (opts && opts.defaultProjectionCode) ? opts.defaultProjectionCode : 'EPSG:3857'
 		this.lastTime = null;
 		this.initialTime = null;
 		this.endIdx = 0;

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
@@ -144,7 +144,8 @@ class N2MapCanvas {
 		this.center = undefined;
 		this.resolution = undefined;
 		this.proj = undefined;
-		this.viewProjectionCode = (opts && opts.defaultProjectionCode) ? opts.defaultProjectionCode : 'EPSG:3857'
+		this.defaultProjection = 'EPSG:3857'
+		this.viewProjectionCode = (opts && opts.defaultProjectionCode) ? opts.defaultProjectionCode : this.defaultProjection
 		this.lastTime = null;
 		this.initialTime = null;
 		this.endIdx = 0;
@@ -660,7 +661,6 @@ class N2MapCanvas {
 				new Projection({ code: 'EPSG:4326' }),
 				_this.n2View.getProjection()
 			);
-
 			customMap.once('postrender', function (evt) {
 				const res = evt.frameState.viewState.resolution;
 				const proj = _this.n2View.getProjection();
@@ -871,7 +871,9 @@ class N2MapCanvas {
 
 		this.editbarControl = new EditBar({
 			interactions: {
-				Select: this.interactionSet.selectInteraction
+				Select: this.interactionSet.selectInteraction,
+				Delete: false,
+				Info: false
 			},
 			source: editLayer.getSource()
 		});

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
@@ -42,7 +42,7 @@ import LayerSwitcher from 'ol-layerswitcher';
 import 'ol-layerswitcher/src/ol-layerswitcher.css';
 
 import 'ol-ext/dist/ol-ext.css';
-import EditBar from 'ol-ext/control/EditBar';
+import EditBar from './EditBar.js';
 import Popup from 'ol-ext/overlay/Popup';
 import Swipe from 'ol-ext/control/Swipe';
 
@@ -103,13 +103,13 @@ class N2MapCanvas {
 			, onError: function (err) { }
 		}, opts_);
 		
-		if(opts.projDefs) {
-			for(const def of opts.projDefs) {
+		if (opts.projDefs) {
+			for (const def of opts.projDefs) {
 				proj4.defs(def.code, def.definition);
 			}
 			register(proj4);
-			for(const d of opts.projDefs) {
-				if(d.extent) {
+			for (const d of opts.projDefs) {
+				if (d.extent) {
 					const p = getProjection(d.code);
 					p.setExtent(d.extent);
 				}
@@ -509,8 +509,7 @@ class N2MapCanvas {
 		if (this.currentMode === this.modes.ADD_OR_SELECT_FEATURE) {
 
 			this.editbarControl.setVisible(true);
-			// this.editbarControl.setModifyWithSelect(true);
-			this.editbarControl.getInteraction('ModifySelect').setActive(true);
+			this.editbarControl.setModifyWithSelect(true);
 			this.editbarControl.deactivateControls();
 			this.editbarControl.setActive(true);
 
@@ -518,16 +517,15 @@ class N2MapCanvas {
 
 		} else if (this.currentMode === this.modes.EDIT_FEATURE) {
 			this.editbarControl.deactivateControls();
-			// this.editbarControl.setModifyWithSelect(true);
+			this.editbarControl.setModifyWithSelect(true);
 			this.editbarControl.setActive(true);
 
 
 		} else if (this.currentMode === this.modes.NAVIGATE) {
 			this.editbarControl.deactivateControls();
-			// this.editbarControl.setModifyWithSelect(false);
-			this.editbarControl.getInteraction('ModifySelect').setActive(false);
+			this.editbarControl.setModifyWithSelect(false);
 			this.editbarControl.setActive(true);
-			// this.editbarControl.deactivateModify();
+			this.editbarControl.deactivateModify();
 			this.editbarControl.setVisible(false);
 			this.editLayerSource.clear();
 		}
@@ -880,7 +878,6 @@ class N2MapCanvas {
 
 		customMap.addControl(this.editbarControl);
 		this.editbarControl.setVisible(false);
-		this.editbarControl.getInteraction('ModifySelect').setActive(false);
 		this.editbarControl.getInteraction('Select').on('clicked', function (e) {
 			if (_this.currentMode === _this.modes.ADD_OR_SELECT_FEATURE
 				|| _this.currentMode === _this.modes.EDIT_FEATURE) {

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
@@ -624,11 +624,15 @@ class N2MapCanvas {
 		const _this = this;
 
 		const drawCenter = this.defaultCenter ? this.defaultCenter : transform([-75, 45.5], 'EPSG:4326', this.viewProjectionCode);
-		const olView = new View({
+		const viewOpts = {
 			center: drawCenter,
 			projection: this.viewProjectionCode,
 			zoom: 6
-		});
+		}
+		if(getProjection(this.viewProjectionCode).getExtent()) {
+			viewOpts.extent = getProjection(this.viewProjectionCode).getExtent()
+		}
+		const olView = new View(viewOpts);
 
 		this.n2View = olView;
 		const customMap = new Map({

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2Select.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2Select.js
@@ -4,6 +4,7 @@
 
 import {getUid} from 'ol/util.js';
 import {default as Interaction} from 'ol/interaction/Interaction.js';
+import ol_interaction_Select from 'ol/interaction/Select.js'
 import Collection from 'ol/Collection.js';
 import {singleClick, never,click, shiftKeyOnly, pointerMove} from 'ol/events/condition.js';
 import Event from 'ol/events/Event.js';
@@ -59,7 +60,7 @@ class N2SelectEvent extends Event {
  * @fires N2SelectEvent
  * @api
  */
-class N2Select extends Interaction {
+class N2Select extends ol_interaction_Select {
 	constructor(opt_options){
 		const options = $n2.extend({
 

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2Select.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2Select.js
@@ -2,11 +2,9 @@
  * @module n2es6/n2mapModule/N2Select
  */
 
-import {getUid} from 'ol/util.js';
 import {default as Interaction} from 'ol/interaction/Interaction.js';
-import ol_interaction_Select from 'ol/interaction/Select.js'
 import Collection from 'ol/Collection.js';
-import {singleClick, never,click, shiftKeyOnly, pointerMove} from 'ol/events/condition.js';
+import {click, pointerMove} from 'ol/events/condition.js';
 import Event from 'ol/events/Event.js';
 var _loc = function(str,args){ return $n2.loc(str,'nunaliit2',args); };
 var DH = 'n2.canvasMap';
@@ -60,7 +58,7 @@ class N2SelectEvent extends Event {
  * @fires N2SelectEvent
  * @api
  */
-class N2Select extends ol_interaction_Select {
+class N2Select extends Interaction {
 	constructor(opt_options){
 		const options = $n2.extend({
 

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/ol5support/N2DonutCluster.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/ol5support/N2DonutCluster.js
@@ -3,7 +3,6 @@
 */
 
 import {getUid} from 'ol/util.js';
-import {assign} from 'ol/obj.js';
 import {listen, unlistenByKey} from 'ol/events.js';
 import EventType from 'ol/events/EventType.js';
 import VectorSource from 'ol/source/Vector.js';
@@ -26,15 +25,16 @@ class N2DonutCluster extends VectorSource {
 	* @param {Options} options CLuster options
 	*/
 	constructor(options) {
-		options = assign({
+		options = {
 			distance: 20,
 			minimumPolygonPixelSize : 20,
 			minimumLinePixelSize : 20,
 			clusterPointsOnly : false,
 			threshold: null,
 			clusterPrefix: null,
-			disableDynamicClustering : false
-		}, options);
+			disableDynamicClustering : false,
+			...options
+		}
 		super(options);
 
 		/**


### PR DESCRIPTION
Add configuration and implementation for `"canvasType": "map"` to set the view projection, handle reprojection to the view and handle projection definitions and restrict map to defined extent. Also includes upgrading OpenLayers to 10.5.

Example new config:
```
"defaultProjectionCode": "EPSG:3572",
	"projDefs": [
		{
			"code": "EPSG:3572",
			"definition": "+proj=laea +lat_0=90 +lon_0=-150 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs",
			"extent": [-9000000, -9000000, 9000000, 9000000]
		},
		{ 
			"code": "EPSG:3413",
			"definition": "+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
			"extent": [-4194304, -4194304, 4194304, 4194304]
		}
	],
```