### PR TITLE
Add date servlet disable config and implementation

### DIFF
--- a/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/AtlasProperties.java
+++ b/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/AtlasProperties.java
@@ -82,6 +82,15 @@ public class AtlasProperties {
 			}
 		}
 
+		// Date servlet
+		{
+			String dateServletDisabledString = props.getProperty("atlas.dateServlet.disabled","false");
+			boolean de = Boolean.parseBoolean(dateServletDisabledString);
+			if( de ){
+				atlasProps.setDateServletDisabled(de);
+			}
+		}
+
 		// Server Key
 		try {
 			String serverKeyString = props.getProperty("server.key",null);
@@ -331,6 +340,7 @@ public class AtlasProperties {
 	private boolean restricted = false;
 	private byte[] serverKey = null;
 	private boolean geometrySimplificationDisabled = false;
+	private boolean dateServletDisabled = false;
 	private String googleMapApiKey;
 
 	public String getAtlasName() {
@@ -458,6 +468,14 @@ public class AtlasProperties {
 
 	public void setGeometrySimplificationDisabled(boolean geometrySimplificationDisabled) {
 		this.geometrySimplificationDisabled = geometrySimplificationDisabled;
+	}
+
+	public boolean isDateServletDisabled() {
+		return dateServletDisabled;
+	}
+
+	public void setDateServletDisabled(boolean dateServletDisabled) {
+		this.dateServletDisabled = dateServletDisabled;
 	}
 
 	public String getGoogleMapApiKey() {

--- a/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/CommandRun.java
+++ b/nunaliit2-couch-command/src/main/java/ca/carleton/gcrc/couch/command/CommandRun.java
@@ -251,11 +251,13 @@ public class CommandRun implements Command {
         }
 
         // Servlet for date
-        {
-        	ServletHolder servletHolder = new ServletHolder(new DateServlet());
-        	servletHolder.setInitOrder(2);
-        	context.addServlet(servletHolder,"/servlet/date/*");
-        }
+		if(!atlasProperties.isDateServletDisabled()) {
+			{
+				ServletHolder servletHolder = new ServletHolder(new DateServlet());
+				servletHolder.setInitOrder(2);
+				context.addServlet(servletHolder,"/servlet/date/*");
+			}
+		}
 
         // Servlet for simplified geometry
         {


### PR DESCRIPTION
Add new config `atlas.dateServlet.disabled=true` that disables the Date Servlet from running including processing and creating the date cluster tree that can get out of control and crash the server. This is a workaround to resolve the issue #1074 