### PR TITLE
support pop-up display on feature hover for ol6

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchConfiguration.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchConfiguration.js
@@ -348,6 +348,11 @@ function Configure(options_){
 		configuration.directory.history = new $n2.history.History({
 			dispatchService: configuration.directory.dispatchService
 		});
+		
+		if(configuration.atlasDb) {
+			
+			console.log("configuration ===============> ", configuration.atlasDb)
+		}
 	
 		// Event translation
 		configuration.directory.eventService = new $n2.couchEvents.EventSupport({
@@ -697,6 +702,14 @@ function Configure(options_){
 			,schemaEditorService: configuration.directory.schemaEditorService
 			,userServerUrl: options.userServerUrl
 			,customService: configuration.directory.customService
+		});
+		
+		new $n2.couchEvents.SelectionRedirector({
+			dispatchService: configuration.directory.dispatchService,
+			eventService: configuration.directory.eventService,
+			atlasDb: configuration.atlasDb,
+			showService: configuration.directory.showService,
+			customService: configuration.directory.customService,
 		});
 		
 	 	configuration.directory.modelService = new $n2.model.Service({

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchConfiguration.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchConfiguration.js
@@ -699,14 +699,6 @@ function Configure(options_){
 			,customService: configuration.directory.customService
 		});
 		
-		new $n2.couchEvents.SelectionRedirector({
-			dispatchService: configuration.directory.dispatchService,
-			eventService: configuration.directory.eventService,
-			atlasDb: configuration.atlasDb,
-			showService: configuration.directory.showService,
-			customService: configuration.directory.customService,
-		});
-		
 	 	configuration.directory.modelService = new $n2.model.Service({
 			dispatchService: configuration.directory.dispatchService
 		});
@@ -834,6 +826,17 @@ function Configure(options_){
 			});
 		};
 		
+		// Load ol default pop-ups
+		if( configuration.atlasDb ){
+			new $n2.couchEvents.SelectionRedirector({
+				dispatchService: configuration.directory.dispatchService,
+				eventService: configuration.directory.eventService,
+				atlasDb: configuration.atlasDb,
+				showService: configuration.directory.showService,
+				customService: configuration.directory.customService,
+			});
+		}
+
 		callCustomConfiguration();
 	};
 	

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.couchConfiguration.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.couchConfiguration.js
@@ -348,11 +348,6 @@ function Configure(options_){
 		configuration.directory.history = new $n2.history.History({
 			dispatchService: configuration.directory.dispatchService
 		});
-		
-		if(configuration.atlasDb) {
-			
-			console.log("configuration ===============> ", configuration.atlasDb)
-		}
 	
 		// Event translation
 		configuration.directory.eventService = new $n2.couchEvents.EventSupport({


### PR DESCRIPTION
Configure `SelectionRedirector` to display pop-ups by default when hovering over features in OpenLayers 6. 

Atlas designers can override this behavior by extending the `SelectionRedirector` class in nunaliit_custom.js to customize the pop-up logic.