### PR TITLE
Support sentinel-2 WMTS

### DIFF
--- a/nunaliit2-js/src/main/js/nunaliit2/n2.mapAndControls.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.mapAndControls.js
@@ -2815,15 +2815,20 @@ var MapAndControls = $n2.Class('MapAndControls',{
 						layerOptions[key] = options[key];
 
 					} else if( 'numZoomLevels' === key){
-						var matrixIds = new Array(options["numZoomLevels"]);
 						var srsName = options['srsName'];
 						var numzoom = options["numZoomLevels"];
-						for (var i=0; i< numzoom; ++i) {
-							matrixIds[i] = srsName + ":" + i;
+						if(!options["noCustomMatrixIds"]) {
+							var matrixIds = new Array(options["numZoomLevels"]);
+							for (var i=0; i< numzoom; ++i) {
+								matrixIds[i] = srsName + ":" + i;
+							}
+							layerOptions.matrixIds = matrixIds;
 						}
-						layerOptions.matrixIds = matrixIds;
 						layerOptions.numZoomLevels = options[key];
-					} else {
+					} else if ('noCustomMatrixIds' === key ) {
+						continue;
+					}
+						else {
 						layerOptions[key] = options[key];
 					};
 				};

--- a/nunaliit2-js/src/main/js/nunaliit2/n2.mapAndControls.js
+++ b/nunaliit2-js/src/main/js/nunaliit2/n2.mapAndControls.js
@@ -2827,8 +2827,7 @@ var MapAndControls = $n2.Class('MapAndControls',{
 						layerOptions.numZoomLevels = options[key];
 					} else if ('noCustomMatrixIds' === key ) {
 						continue;
-					}
-						else {
+					} else {
 						layerOptions[key] = options[key];
 					};
 				};

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
@@ -1318,7 +1318,7 @@ class N2MapCanvas {
 					params: parameters
 				}
 				
-				if(sourceOptionsInternal.attributions) {
+				if (sourceOptionsInternal.attributions) {
 					opts.attributions = sourceOptionsInternal.attributions
 				}
 
@@ -1360,7 +1360,7 @@ class N2MapCanvas {
 					});
 				}
 
-				if(sourceOptionsInternal.attributions) {
+				if (sourceOptionsInternal.attributions) {
 					wmtsOpt.attributions = sourceOptionsInternal.attributions
 				}
 

--- a/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
+++ b/nunaliit2-js/src/main/nunaliit-es6/src/n2es6/n2mapModule/N2MapCanvas.js
@@ -1313,10 +1313,16 @@ class N2MapCanvas {
 					}
 				}
 
-				return new TileWMS({
+				const opts = {
 					url: sourceOptionsInternal.url,
 					params: parameters
-				});
+				}
+				
+				if(sourceOptionsInternal.attributions) {
+					opts.attributions = sourceOptionsInternal.attributions
+				}
+
+				return new TileWMS(opts);
 			} else {
 				$n2.reportError('Parameter is missing for source: ' + sourceTypeInternal);
 			}
@@ -1352,6 +1358,10 @@ class N2MapCanvas {
 						resolutions: resolutions,
 						matrixIds: matrixIds
 					});
+				}
+
+				if(sourceOptionsInternal.attributions) {
+					wmtsOpt.attributions = sourceOptionsInternal.attributions
 				}
 
 				for (let key in options) {


### PR DESCRIPTION
Add attributions option to new WMS and WMTS OL options.
Add new 'noCustomMatrixIds' to ol2 wmts options to use matrix IDs rather then custom string in URL template.