### PR TITLE
Docs: add Ubuntu 24.04 prerequisites guide

### DIFF
--- a/docs/prerequisites/ubuntu-24.04.md
+++ b/docs/prerequisites/ubuntu-24.04.md
@@ -1,0 +1,25 @@
+# Prerequisites: Ubuntu 24.04
+
+This document describes the recommended prerequisites for running Nunaliit on **Ubuntu 24.04 (Noble Numbat)**.
+
+## Overview
+
+The recommended environment is:
+
+- **Operating System:** Ubuntu 24.04 LTS
+- **Java Runtime:** OpenJDK 24
+- **Database:** Apache CouchDB 3.5.x
+
+> Note: Nunaliit requires **Java 11 or newer** at runtime. OpenJDK 24 is recommended for Ubuntu 24.04.
+
+> These commands assume you have administrator privileges. If `sudo` is unavailable in your environment, run them from a root shell (e.g., `su -`) or use your system's approved privilege escalation method.
+
+---
+
+
+## Install OpenJDK 24
+
+Update package lists:
+
+```bash
+sudo apt update


### PR DESCRIPTION
Adds a prerequisites guide for Ubuntu 24.04, with recommended OpenJDK and CouchDB versions.
References: #1292